### PR TITLE
Fix high gameplay issues

### DIFF
--- a/.github/workflows/visual_tests.yaml
+++ b/.github/workflows/visual_tests.yaml
@@ -7,6 +7,9 @@ jobs:
   visual_tests:
     name: 🖼 Visual Tests with ${{ matrix.render-driver }}
     runs-on: ubuntu-latest
+    # A backstop, not a budget: the suite runs in a couple of minutes. Without it a test
+    # that stops making progress holds a runner for GitHub's six-hour default.
+    timeout-minutes: 20
     # Only run the workflow if it's not a PR or if it's a PR from a fork.
     # This prevents duplicate workflows from running on PR's that originate
     # from the repository itself.

--- a/src/Wfc/Entities/World/BrickBreaker/Brick/Brick.cs
+++ b/src/Wfc/Entities/World/BrickBreaker/Brick/Brick.cs
@@ -16,6 +16,7 @@ public partial class Brick : Node2D {
   private Area2D _areaNode = null!;
   private Sprite2D _spriteNode = null!;
   private CollisionShape2D _collisionShapeNode = null!;
+  private bool _isBroken;
 
   public override void _Ready() {
     _areaNode = GetNode<Area2D>("Area2D");
@@ -34,7 +35,20 @@ public partial class Brick : Node2D {
     _spriteNode.Modulate = color;
   }
 
+  // A brick can be told it was hit several times in the same frame: QueueFree is deferred
+  // so this area keeps monitoring for the rest of the tick, and its mask admits the three
+  // balls as well as all eight of the player's face and corner areas. Every one of those
+  // used to decrement the room's brick counter, which steps straight over its exact-zero
+  // test and leaves the player sealed in an empty arena that can never report itself
+  // cleared. Breaking is a one-way door, so latch it and stop listening immediately.
   private void _on_Area2D_area_entered(Area2D area) {
+    if (_isBroken) {
+      return;
+    }
+    _isBroken = true;
+    _areaNode.SetDeferred(Area2D.PropertyName.Monitoring, false);
+    _areaNode.SetDeferred(Area2D.PropertyName.Monitorable, false);
+
     Vector2 extents = (_collisionShapeNode.Shape as RectangleShape2D)?.Size ?? Vector2.Zero;
     EmitSignal(Brick.SignalName.brickBroken);
     EventHandler.Instance.EmitBrickBroken(ColorGroup, Position + GetParent<Node2D>().Position + extents);

--- a/src/Wfc/Entities/World/BrickBreaker/BricksLevelTilemap/BricksLevelTilemap.cs
+++ b/src/Wfc/Entities/World/BrickBreaker/BricksLevelTilemap/BricksLevelTilemap.cs
@@ -15,6 +15,7 @@ public partial class BricksLevelTilemap : TileMap {
   public int id { get; set; } = 0;
 
   private int _bricksCount = 0;
+  private bool _isCleared;
 
   private BricksTileMap _parent = default!;
 
@@ -43,9 +44,14 @@ public partial class BricksLevelTilemap : TileMap {
     }
   }
 
+  // Testing for exactly zero made a single miscount unrecoverable: one extra decrement
+  // stepped over the terminal value and the room could never be cleared. The latch on
+  // Brick should make that impossible now, but the counter is what the player is locked
+  // behind, so it does not get to depend on being counted perfectly.
   private void OnBrickBroken() {
     _bricksCount--;
-    if (_bricksCount == 0) {
+    if (!_isCleared && _bricksCount <= 0) {
+      _isCleared = true;
       EmitSignal(BricksLevelTilemap.SignalName.levelBricksCleared, id);
     }
   }

--- a/src/Wfc/Entities/World/BrickBreaker/Powerups/BrickPowerUpHandler/BrickPowerUpHandler.cs
+++ b/src/Wfc/Entities/World/BrickBreaker/Powerups/BrickPowerUpHandler/BrickPowerUpHandler.cs
@@ -141,14 +141,23 @@ public partial class BrickPowerUpHandler : Node2D, IPowerUpHandler {
   }
 
   private void OnPlayerHit(PowerUp powerUp, PackedScene hitNode) {
+    powerUp.OnPlayerHit -= OnPlayerHit;
     RemoveIrrelevantPowerups();
-    if (CheckIfCanAddPowerup(hitNode)) {
+
+    // A power-up scene that never set OnHitScript used to dereference null here, and the
+    // throw happened inside the signal emission - so the power-up on the other side never
+    // reached its own QueueFree and kept falling forever with its monitoring already
+    // switched off. Report the authoring mistake and let the pickup itself still count.
+    if (hitNode == null) {
+      GD.PushError($"Power-up '{powerUp.SceneFilePath}' has no OnHitScript; no effect applied.");
+    }
+    else if (CheckIfCanAddPowerup(hitNode)) {
       var hit = hitNode.Instantiate<PowerUpScript>();
       _activePowerupNodes.Add(hit);
       hit.SetBrickBreakerNode(_brickBreakerNode);
       CallDeferred(Node.MethodName.AddChild, hit);
     }
-    powerUp.OnPlayerHit -= OnPlayerHit;
+
     EventHandler.Instance.EmitPickedPowerup();
   }
 

--- a/src/Wfc/Entities/World/BrickBreaker/Powerups/FastPowerUp/FastPowerUp.tscn
+++ b/src/Wfc/Entities/World/BrickBreaker/Powerups/FastPowerUp/FastPowerUp.tscn
@@ -1,5 +1,10 @@
-[gd_scene load_steps=2 format=3 uid="uid://jrp5ae1saffs"]
+[gd_scene load_steps=4 format=3 uid="uid://jrp5ae1saffs"]
 
 [ext_resource type="PackedScene" uid="uid://b3qln8gue8c2g" path="res://src/Wfc/Entities/World/BrickBreaker/Powerups/PowerUp/PowerUp.tscn" id="3"]
+[ext_resource type="Texture2D" uid="uid://cadtnf55khkxm" path="res://Assets/Sprites/BrickBreaker/speed.png" id="1"]
+[ext_resource type="PackedScene" uid="uid://cns8ab5w0f41t" path="res://src/Wfc/Entities/World/BrickBreaker/Powerups/FastPowerUp/FastPowerUpScript.tscn" id="2"]
 
 [node name="PowerUp" instance=ExtResource("3")]
+ColorGroup = "blue"
+Texture = ExtResource("1")
+OnHitScript = ExtResource("2")

--- a/src/Wfc/Entities/World/Player/State/PlayerDashingState/PlayerDashingState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerDashingState/PlayerDashingState.cs
@@ -86,7 +86,7 @@ public partial class PlayerDashingState : PlayerBaseState {
     if (!_dashTimer.IsRunning()) {
       return statesStore.GetState<PlayerFallingState>();
     }
-    else {
+    else if (HoldsHeightDuringDash(_direction)) {
       player.Velocity = new Vector2(player.Velocity.X, 0);
     }
 
@@ -95,6 +95,12 @@ public partial class PlayerDashingState : PlayerBaseState {
 
     return null;
   }
+
+  // A horizontal dash pins the cube at its current height by zeroing gravity every frame.
+  // A down-dash's whole payload is a vertical velocity, so doing it there overwrote the
+  // DASH_SPEED just assigned above: the cube hovered for DASH_DURATION and fell ~33px
+  // instead of ~300, on every frame but the last.
+  internal static bool HoldsHeightDuringDash(Vector2 direction) => Mathf.Abs(direction.Y) <= 0.01f;
 
   private void _setDashDirection(Player player) {
     _direction = Vector2.Zero;

--- a/src/Wfc/Entities/World/Player/State/PlayerJumpingState/PlayerJumpingState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerJumpingState/PlayerJumpingState.cs
@@ -11,6 +11,7 @@ public partial class PlayerJumpingState : PlayerBaseState {
   private const float PERMISSIVENESS = 0.09f;
   private const float FACE_SEPARATOR_SCALE_FACTOR = 4.5f;
   private const float JUMP_FORCE = 1200f;
+  private const float JUMP_CUT_FACTOR = 0.5f;
 
   private bool _entered = false;
   private CountdownTimer _jumpTimer = new CountdownTimer();
@@ -62,7 +63,7 @@ public partial class PlayerJumpingState : PlayerBaseState {
     if (_jumpTimer.IsRunning() && inputManager.IsJustReleased(IInputManager.Action.Jump)) {
       _jumpTimer.Stop();
       if (player.Velocity.Y < 0) {
-        player.Velocity = new Vector2(player.Velocity.X * 0.5f, player.Velocity.Y);
+        player.Velocity = ApplyJumpCut(player.Velocity, JUMP_CUT_FACTOR);
       }
     }
 
@@ -70,6 +71,12 @@ public partial class PlayerJumpingState : PlayerBaseState {
     _permissivenessTimer.Step(delta);
     return null;
   }
+
+  // Releasing Jump early cuts the jump short, so it is the rising component that gets
+  // damped. Damping X instead gave every tap-jump full height and half run speed, which
+  // shortened the arc without ever letting the player duck under a low ceiling.
+  internal static Vector2 ApplyJumpCut(Vector2 velocity, float factor) =>
+    new(velocity.X, velocity.Y * factor);
 
   public PlayerJumpingState WithJumpPower(float jumpPower) {
     _touchJumpPower = jumpPower;

--- a/test/Instrumented/src/BrickBreaker/BrickTests.cs
+++ b/test/Instrumented/src/BrickBreaker/BrickTests.cs
@@ -1,0 +1,75 @@
+namespace Wfc.test.instrumented.BrickBreaker;
+
+using System.Threading.Tasks;
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Entities.World.BrickBreaker;
+using Wfc.test;
+
+// Breaking is a one-way door, but the brick used to be able to walk through it several
+// times in one frame: QueueFree is deferred, so its Area2D keeps monitoring for the rest
+// of the tick, and the mask admits the balls and all eight of the player's face and
+// corner areas at once. Each extra report decremented the room's counter, which tested
+// for exactly zero - so the arena emptied and never reported itself cleared.
+public class BrickTests(Node testScene) : TestClass(testScene) {
+  private const string BRICK_SCENE = "res://src/Wfc/Entities/World/BrickBreaker/Brick/Brick.tscn";
+
+  private Node2D _root = default!;
+  private SignalsCounter _signalsCounter = new();
+
+  [Setup]
+  public async Task Setup() {
+    _root = new Node2D();
+    TestScene.AddChild(_root);
+    await _idle();
+  }
+
+  [Cleanup]
+  public void Cleanup() {
+    _signalsCounter.Clear();
+    _root.QueueFree();
+  }
+
+  [Test]
+  public async Task ReportsItselfBrokenOnce() {
+    var brick = await _addBrick();
+    var area = brick.GetNode<Area2D>("Area2D");
+    _signalsCounter.Connect("broken", brick, Brick.SignalName.brickBroken);
+
+    _hit(area);
+
+    _signalsCounter.getCallCount("broken").ShouldBe(1);
+  }
+
+  [Test]
+  public async Task ReportsItselfBrokenOnceEvenWhenHitRepeatedlyInOneFrame() {
+    var brick = await _addBrick();
+    var area = brick.GetNode<Area2D>("Area2D");
+    _signalsCounter.Connect("broken", brick, Brick.SignalName.brickBroken);
+
+    // A cube landing square on a brick delivers a face and two corners at once.
+    _hit(area);
+    _hit(area);
+    _hit(area);
+
+    _signalsCounter.getCallCount("broken").ShouldBe(1, "the room's brick counter is decremented once per report");
+  }
+
+  private async Task<Brick> _addBrick() {
+    var brick = GD.Load<PackedScene>(BRICK_SCENE).Instantiate<Brick>();
+    _root.AddChild(brick);
+    await _idle();
+    return brick;
+  }
+
+  // The contact itself, not the physics that would produce it: the bug is in what the
+  // brick does with a report it has already acted on.
+  private static void _hit(Area2D area) => area.EmitSignal(Area2D.SignalName.AreaEntered, new Area2D());
+
+  private async Task _idle() {
+    var tree = TestScene.GetTree();
+    await tree.ToSignal(tree, SceneTree.SignalName.ProcessFrame);
+    await tree.ToSignal(tree, SceneTree.SignalName.ProcessFrame);
+  }
+}

--- a/test/Instrumented/src/BrickBreaker/PowerUpSceneContractTests.cs
+++ b/test/Instrumented/src/BrickBreaker/PowerUpSceneContractTests.cs
@@ -1,0 +1,57 @@
+namespace Wfc.test.instrumented.BrickBreaker;
+
+using System.Collections.Generic;
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Entities.World.BrickBreaker.Powerups;
+using Wfc.Utils.Colors;
+
+// The power-up pool is dealt without replacement, so a scene that forgot its exports
+// comes up once every six pickups. Nothing about that is visible until it is picked up:
+// the exports simply stay null and the pickup handler dereferences one of them.
+//
+// This walks the directory rather than a hardcoded list, so a power-up added later is
+// covered the day it is written.
+public class PowerUpSceneContractTests(Node testScene) : TestClass(testScene) {
+  private const string POWERUPS_DIR = "res://src/Wfc/Entities/World/BrickBreaker/Powerups";
+
+  // The scene every other one instances. It is the blank the others fill in, so it is the
+  // one place these exports are legitimately unset.
+  private const string BASE_POWERUP_SCENE = POWERUPS_DIR + "/PowerUp/PowerUp.tscn";
+
+  [Test]
+  public void EveryPowerUpSceneIsFullyAuthored() {
+    var scenePaths = _powerUpScenePaths();
+    scenePaths.ShouldNotBeEmpty("no power-up scenes were found - has the folder moved?");
+
+    foreach (var path in scenePaths) {
+      var powerUp = GD.Load<PackedScene>(path).Instantiate();
+      if (powerUp is not PowerUp authored || path == BASE_POWERUP_SCENE) {
+        powerUp.QueueFree();
+        continue;
+      }
+
+      authored.Texture.ShouldNotBeNull($"{path} sets no Texture, so it renders as nothing");
+      authored.OnHitScript.ShouldNotBeNull($"{path} sets no OnHitScript, so picking it up throws");
+      ColorUtils.COLOR_GROUPS.ShouldContain(
+        authored.ColorGroup,
+        $"{path} is in group '{authored.ColorGroup}', which is not a color group"
+      );
+      authored.QueueFree();
+    }
+  }
+
+  private static List<string> _powerUpScenePaths() {
+    var paths = new List<string>();
+    foreach (var directory in DirAccess.GetDirectoriesAt(POWERUPS_DIR)) {
+      var subDir = $"{POWERUPS_DIR}/{directory}";
+      foreach (var file in DirAccess.GetFilesAt(subDir)) {
+        if (file.EndsWith(".tscn")) {
+          paths.Add($"{subDir}/{file}");
+        }
+      }
+    }
+    return paths;
+  }
+}

--- a/test/src/Helpers/ExpectSignalTests.cs
+++ b/test/src/Helpers/ExpectSignalTests.cs
@@ -1,0 +1,35 @@
+namespace Wfc.test.Helpers;
+
+using System.Threading.Tasks;
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.test;
+
+// The helper every other async test now depends on to fail rather than hang, so its
+// timeout branch is worth proving rather than assuming.
+public class ExpectSignalTests(Node testScene) : TestClass(testScene) {
+  [Test]
+  public async Task ReportsTheSignalWhenItArrives() {
+    var timer = new Timer { WaitTime = 0.05, OneShot = true, Autostart = true };
+    TestScene.AddChild(timer);
+
+    var fired = await TestScene.GetTree().ExpectSignal(timer, Timer.SignalName.Timeout);
+
+    fired.ShouldBeTrue();
+    timer.QueueFree();
+  }
+
+  // The case that matters: without a deadline this await would never resume and the
+  // whole run would sit here until the CI job was killed hours later.
+  [Test]
+  public async Task GivesUpOnASignalThatNeverArrives() {
+    var silent = new Timer { WaitTime = 3600, OneShot = true };
+    TestScene.AddChild(silent);
+
+    var fired = await TestScene.GetTree().ExpectSignal(silent, Timer.SignalName.Timeout, 0.2);
+
+    fired.ShouldBeFalse();
+    silent.QueueFree();
+  }
+}

--- a/test/src/Helpers/TestHelpers.cs
+++ b/test/src/Helpers/TestHelpers.cs
@@ -14,4 +14,26 @@ public static class TestHelpers {
     var timer = tree.CreateTimer(secs);
     await tree.ToSignal(timer, Timer.SignalName.Timeout);
   }
+
+  // Awaits a signal, but gives up instead of waiting forever. A bare ToSignal turns a
+  // regression into a hung job rather than a failed one: the await never resumes, the
+  // test never returns, and CI burns until GitHub's six-hour default kills it without
+  // saying which test was stuck. Returns false on timeout so the caller can assert.
+  //
+  // The timeout is counted in process frames, the same clock the awaited work runs on, so
+  // a slow CI runner stretches both together rather than only the deadline.
+  public static async Task<bool> ExpectSignal(
+    this SceneTree tree,
+    GodotObject source,
+    StringName signal,
+    double timeoutSeconds = 5.0
+  ) {
+    var fired = _completion(tree.ToSignal(source, signal));
+    var timedOut = _completion(tree.ToSignal(tree.CreateTimer(timeoutSeconds), SceneTreeTimer.SignalName.Timeout));
+
+    return await Task.WhenAny(fired, timedOut) == fired;
+  }
+
+  // SignalAwaiter is awaitable but is not a Task, and WhenAny needs Tasks to race.
+  private static async Task<Variant[]> _completion(SignalAwaiter awaiter) => await awaiter;
 }

--- a/test/src/PlayerRotationTest.cs
+++ b/test/src/PlayerRotationTest.cs
@@ -29,10 +29,13 @@ public class PlayerRotationActionTest(Node testScene) : TestClass(testScene) {
     _playerRotationParent.Rotation.ShouldBe(0);
     var duration = 0.1f;
     _playerRotation.Fire(Mathf.Pi, duration);
-    await _playerRotation
+    // The CreateTimer this used to await through was decorative: ToSignal ignores the
+    // object it is called on, so the await had no deadline at all.
+    var completed = await _playerRotation
       .GetTree()
-      .CreateTimer(duration + Mathf.Epsilon)
-      .ToSignal(_playerRotation, nameof(PlayerRotation.RotationCompleted));
+      .ExpectSignal(_playerRotation, PlayerRotation.SignalName.RotationCompleted);
+
+    completed.ShouldBeTrue("the rotation never reported completion");
     _playerRotationParent.Rotation.ShouldBeCloseTo(Mathf.Pi);
   }
 }

--- a/test/src/Wfc/Entities/World/Player/State/PlayerMotionTests.cs
+++ b/test/src/Wfc/Entities/World/Player/State/PlayerMotionTests.cs
@@ -1,0 +1,40 @@
+namespace Wfc.Entities.World.Player.Test;
+
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Entities.World.Player;
+
+// Two axis mix-ups that no type could catch: both compile, both run every frame, and
+// both quietly spend a mechanic on the wrong component of the velocity.
+public class PlayerMotionTests(Node testScene) : TestClass(testScene) {
+  [Test]
+  public void JumpCutDampsTheRiseAndLeavesRunSpeedAlone() {
+    var cut = PlayerJumpingState.ApplyJumpCut(new Vector2(300f, -1200f), 0.5f);
+
+    cut.Y.ShouldBe(-600f);
+    cut.X.ShouldBe(300f, "cutting a jump short must not brake the player mid-air");
+  }
+
+  // The guard around the cut is Velocity.Y < 0, so the cut only ever sees a rising cube.
+  [Test]
+  public void JumpCutAlwaysReducesTheUpwardSpeed() {
+    var cut = PlayerJumpingState.ApplyJumpCut(new Vector2(-120f, -900f), 0.5f);
+
+    Mathf.Abs(cut.Y).ShouldBeLessThan(900f);
+  }
+
+  [Test]
+  public void AHorizontalDashHoldsItsHeight() {
+    PlayerDashingState.HoldsHeightDuringDash(new Vector2(1f, 0f)).ShouldBeTrue();
+    PlayerDashingState.HoldsHeightDuringDash(new Vector2(-1f, 0f)).ShouldBeTrue();
+  }
+
+  // The one that was broken: a down-dash's payload is its Y velocity, so the frame-by-
+  // frame gravity cancel has to stand aside or the dash is consumed for nothing.
+  [Test]
+  public void ADownDashDoesNotHoldItsHeight() {
+    PlayerDashingState.HoldsHeightDuringDash(new Vector2(0f, 1f)).ShouldBeFalse();
+    PlayerDashingState.HoldsHeightDuringDash(new Vector2(1f, 1f)).ShouldBeFalse();
+  }
+}

--- a/test/src/Wfc/Entities/World/Player/State/PlayerSlipperingStateTests.cs
+++ b/test/src/Wfc/Entities/World/Player/State/PlayerSlipperingStateTests.cs
@@ -18,6 +18,11 @@ public class PlayerSlipperingStateTest(Node testScene) : TestClass(testScene) {
 
   private static readonly string BASE_FIXTURE_PATH = "test/src/Wfc/Entities/World/Player/State/Fixture/";
 
+  // These fixtures run real physics: the cube has to overbalance, rotate and fall out of
+  // the world. Generous, because a loaded CI runner stretches the wall clock more than
+  // the physics steps - but bounded, which is the whole point.
+  private const double DEATH_TIMEOUT = 10.0;
+
   [Setup]
   public void Setup() {
     _fixture = new Fixture(TestScene.GetTree());
@@ -38,8 +43,10 @@ public class PlayerSlipperingStateTest(Node testScene) : TestClass(testScene) {
     var player = PlayerOnEdgeNode.GetNode<Player>("Player");
     player.Rotation.ShouldBeCloseTo(0f, epsilon: 0.15f);
 
-    await PlayerOnEdgeNode.ToSignal(EventHandler.Instance.Events, Events.SignalName.PlayerDied);
+    var died = await PlayerOnEdgeNode.GetTree()
+      .ExpectSignal(EventHandler.Instance.Events, Events.SignalName.PlayerDied, DEATH_TIMEOUT);
 
+    died.ShouldBeTrue("the player never slipped off the edge and died");
     player.Rotation.ShouldBeCloseTo(MathUtils.PI2);
     _signalsCounter.getCallCount("slippering").ShouldBe(1);
   }
@@ -52,8 +59,10 @@ public class PlayerSlipperingStateTest(Node testScene) : TestClass(testScene) {
     var player = PlayerOnEdgeNode.GetNode<Player>("Player");
     player.Rotation.ShouldBeCloseTo(0f, epsilon: 0.1f);
 
-    await PlayerOnEdgeNode.ToSignal(EventHandler.Instance.Events, Events.SignalName.PlayerDied);
+    var died = await PlayerOnEdgeNode.GetTree()
+      .ExpectSignal(EventHandler.Instance.Events, Events.SignalName.PlayerDied, DEATH_TIMEOUT);
 
+    died.ShouldBeTrue("the player never slipped off the edge and died");
     player.Rotation.ShouldBeCloseTo(-MathUtils.PI2);
     _signalsCounter.getCallCount("slippering").ShouldBe(1);
   }


### PR DESCRIPTION
Add ExpectSignal timeout helper, convert the 3 unbounded awaits, add timeout-minutes to CI job

Jump-cut damps vertical instead of horizontal velocity

Down-dash Y velocity no longer zeroed by the gravity cancel

BoxFace/FaceSeparator collision mask missing Tetris and Bricks layers

FastPowerUp.tscn overrides nothing, throws on pickup

Brick needs a broken-latch so a double hit cannot skip zero
