### PR TITLE
Player collision re-design

### DIFF
--- a/src/Wfc/Entities/World/BrickBreaker/Powerups/PowerUp/PowerUp.cs
+++ b/src/Wfc/Entities/World/BrickBreaker/Powerups/PowerUp/PowerUp.cs
@@ -55,14 +55,21 @@ public partial class PowerUp : Node2D {
   }
 
   private void _onArea2DBodyEntered(Node body) {
-    if (body == Global.Instance().Player) {
-      if (!Global.Instance().Player.IsDying()) {
-        AreaNode.SetDeferred(Area2D.PropertyName.Monitorable, false);
-        AreaNode.SetDeferred(Area2D.PropertyName.Monitoring, false);
-        EmitSignal(nameof(OnPlayerHit), this, OnHitScript);
-        QueueFree();
-      }
+    var player = Global.Instance().Player;
+    if (body != player || player.IsDying()) {
+      return;
     }
+    // A power-up wears the color of the brick it fell from, and the cube has to be showing that
+    // color where it catches it. The tint was decorative until now, which reads as a rule in a
+    // game whose only rule is that color decides what you may touch - so a wrong-colored one
+    // falls straight through instead of killing, which would make the arena a gauntlet.
+    if (!player.AcceptsColorOfAt(AreaNode.GlobalPosition, AreaNode)) {
+      return;
+    }
+    AreaNode.SetDeferred(Area2D.PropertyName.Monitorable, false);
+    AreaNode.SetDeferred(Area2D.PropertyName.Monitoring, false);
+    EmitSignal(nameof(OnPlayerHit), this, OnHitScript);
+    QueueFree();
   }
 
   private void _onArea2DAreaEntered(Area2D area) {

--- a/src/Wfc/Entities/World/BrickBreaker/Powerups/PowerUp/PowerUp.tscn
+++ b/src/Wfc/Entities/World/BrickBreaker/Powerups/PowerUp/PowerUp.tscn
@@ -1,13 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://b3qln8gue8c2g"]
+[gd_scene load_steps=4 format=3 uid="uid://b3qln8gue8c2g"]
 
 [ext_resource type="Texture2D" uid="uid://dcosdtmurf2w2" path="res://Assets/Sprites/BrickBreaker/power-up-circle.png" id="1"]
 [ext_resource type="Script" uid="uid://b7mycb6pq65iu" path="res://src/Wfc/Entities/World/BrickBreaker/Powerups/PowerUp/PowerUp.cs" id="2"]
 
 [sub_resource type="CircleShape2D" id="1"]
 radius = 24.0
-
-[sub_resource type="CircleShape2D" id="2"]
-radius = 23.3452
 
 [node name="PowerUp" type="Node2D"]
 script = ExtResource("2")
@@ -23,13 +20,6 @@ collision_mask = 19
 shape = SubResource("1")
 
 [node name="Spr" type="Sprite2D" parent="."]
-
-[node name="StaticBody2D" type="StaticBody2D" parent="."]
-collision_layer = 256
-collision_mask = 18
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
-shape = SubResource("2")
 
 [connection signal="area_entered" from="Area2D" to="." method="_onArea2DAreaEntered"]
 [connection signal="body_entered" from="Area2D" to="." method="_onArea2DBodyEntered"]

--- a/src/Wfc/Entities/World/Camera/CameraLocalizer/CameraLocalizer.cs
+++ b/src/Wfc/Entities/World/Camera/CameraLocalizer/CameraLocalizer.cs
@@ -277,7 +277,7 @@ public partial class CameraLocalizer : Node2D {
     if (GameLevel.PlayerNode is not { } playerNode) {
       return;
     }
-    var half = playerNode.GetCollisionShapeSize() * playerNode.Scale * 0.5f;
+    var half = playerNode.GetCollisionHalfExtents();
     var min = playerNode.GlobalPosition - half;
     var max = playerNode.GlobalPosition + half;
 

--- a/src/Wfc/Entities/World/Enemies/Bullet/Bullet.cs
+++ b/src/Wfc/Entities/World/Enemies/Bullet/Bullet.cs
@@ -7,6 +7,7 @@ using Wfc.Entities.World.Player;
 using Wfc.Skin;
 using Wfc.Utils;
 using Wfc.Utils.Attributes;
+using EventHandler = Wfc.Core.Event.EventHandler;
 
 [ScenePath]
 public partial class Bullet : Node2D, IBullet {
@@ -57,16 +58,15 @@ public partial class Bullet : Node2D, IBullet {
     }
   }
 
-  private void _on_ColorArea_body_entered(Node body) {
+  // The cube's own color query, at the point the bullet reached it, rather than whichever of the
+  // cube's collision shapes the contact was reported against. A shape index says nothing about
+  // how near a corner the bullet struck, so the corner seam every other collision partner is
+  // judged against never reached bullets at all.
+  private void _onColorAreaBodyEntered(Node body) {
+    if (body == Global.Instance().Player && body is Player player && !player.IsDying()
+        && !player.AcceptsColorOfAt(_colorAreaNode.GlobalPosition, _colorAreaNode)) {
+      EventHandler.Instance.EmitPlayerDying(_colorAreaNode, player.GlobalPosition, EntityType.Bullet);
+    }
     QueueFree();
-  }
-
-  private void _onColorAreaBodyShapeEntered(Rid bodyRid, Node body, uint bodyShapeIndex, int localShapeIndex) {
-    if (body != Global.Instance().Player) {
-      return;
-    }
-    if (body is Player player) {
-      player.OnFastAreaCollidingWithPlayerShape(bodyShapeIndex, _colorAreaNode, EntityType.Bullet);
-    }
   }
 }

--- a/src/Wfc/Entities/World/Enemies/Bullet/Bullet.tscn
+++ b/src/Wfc/Entities/World/Enemies/Bullet/Bullet.tscn
@@ -28,5 +28,4 @@ collision_mask = 23
 scale = Vector2(1.05, 1.05)
 shape = SubResource("2")
 
-[connection signal="body_entered" from="CharacterBody2D/ColorArea" to="." method="_on_ColorArea_body_entered"]
-[connection signal="body_shape_entered" from="CharacterBody2D/ColorArea" to="." method="_onColorAreaBodyShapeEntered"]
+[connection signal="body_entered" from="CharacterBody2D/ColorArea" to="." method="_onColorAreaBodyEntered"]

--- a/src/Wfc/Entities/World/Player/Face/BaseFace/BaseFace.cs
+++ b/src/Wfc/Entities/World/Player/Face/BaseFace/BaseFace.cs
@@ -1,25 +1,23 @@
 namespace Wfc.Entities.World.Player;
 
-using System;
 using Godot;
-using Wfc.Entities.World.Gems;
-using Wfc.Utils;
-using Wfc.Utils.Attributes;
 
 public partial class BaseFace : Area2D {
   protected CollisionShape2D CollisionShapeNode { get; private set; } = null!;
-  public float EdgeLength { get; protected set; }
+  protected RectangleShape2D? ShapeRect { get; private set; }
 
-  protected Vector2 Extents;
-
-  protected float PositionX { get; private set; }
-  protected float PositionY { get; private set; }
+  // The area's extent along the edge it lies on, as authored. The seam is laid out from it, so
+  // it stays at the authored value however the areas are later resized.
+  public float EdgeLength { get; private set; }
 
   public override void _Ready() {
     CollisionShapeNode = GetNode<CollisionShape2D>("CollisionShape2D");
-    Extents = (CollisionShapeNode.Shape as RectangleShape2D)?.Size ?? Vector2.Zero;
-    PositionX = Position.X;
-    PositionY = Position.Y;
+    // One shape resource is shared by every instance of this scene, and Godot keeps it cached
+    // for the next level as well. Resizing a seam without duplicating first would resize all
+    // four faces at once and outlive the player it was resized for.
+    CollisionShapeNode.Shape = (Shape2D)CollisionShapeNode.Shape.Duplicate();
+    ShapeRect = CollisionShapeNode.Shape as RectangleShape2D;
+    EdgeLength = ShapeRect?.Size.X ?? 0f;
   }
 
   // A face's groups are the colors it is allowed to touch: one for a flat face, two for a
@@ -38,12 +36,11 @@ public partial class BaseFace : Area2D {
 
   public bool AcceptsColor(string colorGroup) => IsInGroup(colorGroup);
 
-  public virtual void ScaleBy(float factor) {
-    float scaleFactor = factor;
-    Scale = new Vector2(scaleFactor, scaleFactor);
-    Position = new Vector2(
-        PositionX - Extents.X * (scaleFactor - 1.0f) * Math.Sign(Position.X) * 0.5f,
-        PositionY - Extents.Y * (scaleFactor - 1.0f) * Math.Sign(Position.Y) * 0.5f
-    );
+  // Along the edge only. Thickness is authored and stays put: it sets how deep a contact has to
+  // be before it registers, which has nothing to do with how forgiving a corner is.
+  public void SetEdgeLength(float length) {
+    if (ShapeRect is not null) {
+      ShapeRect.Size = new Vector2(length, ShapeRect.Size.Y);
+    }
   }
 }

--- a/src/Wfc/Entities/World/Player/Face/BoxCorner/BoxCorner.cs
+++ b/src/Wfc/Entities/World/Player/Face/BoxCorner/BoxCorner.cs
@@ -1,12 +1,16 @@
 namespace Wfc.Entities.World.Player;
 
-using System;
 using Godot;
 using Wfc.Core.Event;
 using Wfc.Entities.World.Gems;
 using EventHandler = Wfc.Core.Event.EventHandler;
 
 public partial class BoxCorner : BaseFace {
+  private Vector2 _outerCorner;
+
+  // How far this corner's outer corner stands from the cube's center along each axis. The seam
+  // grows about it, so making the corners more forgiving never changes the cube's silhouette.
+  public float OuterReach => Mathf.Abs(_outerCorner.X);
 
   public override void _EnterTree() {
     base._EnterTree();
@@ -20,8 +24,14 @@ public partial class BoxCorner : BaseFace {
 
   public override void _Ready() {
     base._Ready();
-    RectangleShape2D? collisionShape = CollisionShapeNode.Shape as RectangleShape2D;
-    EdgeLength = collisionShape?.Size.X ?? 0;
+    _outerCorner = Position + (Position.Sign() * EdgeLength * 0.5f);
+  }
+
+  public void SetSeamSide(float side) {
+    if (ShapeRect is not null) {
+      ShapeRect.Size = new Vector2(side, side);
+    }
+    Position = _outerCorner - (_outerCorner.Sign() * side * 0.5f);
   }
 
   public void _onAreaEntered(Area2D area) {

--- a/src/Wfc/Entities/World/Player/Face/BoxCorner/CornerCollisionShape.tscn
+++ b/src/Wfc/Entities/World/Player/Face/BoxCorner/CornerCollisionShape.tscn
@@ -1,7 +1,0 @@
-[gd_scene load_steps=2 format=3 uid="uid://c7s2e6euryym8"]
-
-[sub_resource type="RectangleShape2D" id="1"]
-size = Vector2(4, 4)
-
-[node name="FaceCollisionShape" type="CollisionShape2D"]
-shape = SubResource("1")

--- a/src/Wfc/Entities/World/Player/Face/BoxFace/BoxFace.cs
+++ b/src/Wfc/Entities/World/Player/Face/BoxFace/BoxFace.cs
@@ -1,9 +1,7 @@
 namespace Wfc.Entities.World.Player;
 
-using System;
 using Godot;
 using Wfc.Core.Event;
-using Wfc.Entities.World.Gems;
 using EventHandler = Wfc.Core.Event.EventHandler;
 
 public partial class BoxFace : BaseFace {
@@ -16,21 +14,6 @@ public partial class BoxFace : BaseFace {
   public override void _ExitTree() {
     base._ExitTree();
     AreaEntered -= _onAreaEntered;
-  }
-
-  public override void _Ready() {
-    base._Ready();
-    EdgeLength = ((CollisionShapeNode.Shape as RectangleShape2D)?.Size.X) ?? 0f;
-  }
-
-  public override void ScaleBy(float factor) {
-    float scaleFactor = factor;
-    Scale = new Vector2(scaleFactor, scaleFactor);
-
-    Position = new Vector2(
-        PositionX + Extents.Y * (scaleFactor - 1.0f) * Math.Sign(Position.Y) * Mathf.Sin(Rotation),
-        PositionY - Extents.Y * (scaleFactor - 1.0f) * Math.Sign(Position.Y) * Mathf.Cos(Rotation)
-    );
   }
 
   public void _onAreaEntered(Area2D area) {

--- a/src/Wfc/Entities/World/Player/Face/BoxFace/FaceCollisionShape.tscn
+++ b/src/Wfc/Entities/World/Player/Face/BoxFace/FaceCollisionShape.tscn
@@ -1,7 +1,0 @@
-[gd_scene load_steps=2 format=3 uid="uid://l65bdg6xvfrs"]
-
-[sub_resource type="RectangleShape2D" id="1"]
-size = Vector2(4, 87.4)
-
-[node name="FaceCollisionShape" type="CollisionShape2D"]
-shape = SubResource("1")

--- a/src/Wfc/Entities/World/Player/Player/Player.cs
+++ b/src/Wfc/Entities/World/Player/Player/Player.cs
@@ -82,22 +82,6 @@ public partial class Player : CharacterBody2D, IPersistent {
   private BoxFace _leftFaceNode = null!;
   [NodePath("RightFace")]
   private BoxFace _rightFaceNode = null!;
-  [NodePath("FaceCollisionShapeL")]
-  private CollisionShape2D FaceCollisionShapeL_node = null!;
-  [NodePath("FaceCollisionShapeR")]
-  private CollisionShape2D FaceCollisionShapeR_node = null!;
-  [NodePath("FaceCollisionShapeT")]
-  private CollisionShape2D FaceCollisionShapeT_node = null!;
-  [NodePath("FaceCollisionShapeB")]
-  private CollisionShape2D FaceCollisionShapeB_node = null!;
-  [NodePath("FaceCollisionShapeTL")]
-  public CollisionShape2D FaceCollisionShapeTL_node = null!;
-  [NodePath("FaceCollisionShapeTR")]
-  public CollisionShape2D FaceCollisionShapeTR_node = null!;
-  [NodePath("FaceCollisionShapeBL")]
-  public CollisionShape2D FaceCollisionShapeBL_node = null!;
-  [NodePath("FaceCollisionShapeBR")]
-  public CollisionShape2D FaceCollisionShapeBR_node = null!;
   [NodePath("CollisionShape2D")]
   private CollisionShape2D _collisionShapeNode = null!;
   [NodePath("AnimatedSprite2D")]
@@ -106,8 +90,6 @@ public partial class Player : CharacterBody2D, IPersistent {
   public Timer DashGhostTimerNode = null!;
   private List<BoxCorner> faceSeparatorNodes = new List<BoxCorner>();
   private List<BoxFace> faceNodes = new List<BoxFace>();
-  private List<CollisionShape2D> faceCollisionNodes = new List<CollisionShape2D>();
-  private List<CollisionShape2D> faceCornerCollisionNodes = new List<CollisionShape2D>();
   #endregion Nodes
 
   private SaveData _saveData = new SaveData();
@@ -117,10 +99,9 @@ public partial class Player : CharacterBody2D, IPersistent {
   private List<Dictionary<string, int>> _faceNodesMaskBackup = new List<Dictionary<string, int>>();
   private bool _colorAreasAreHidden;
 
-
-
   public float CurrentDefaultCornerScaleFactor { get; set; } = 1.0f;
   private float _currentScaleFactor = 1.0f; // Do not edit by yourself this is used by scale_corners_by
+  private PlayerBox.Ring _colorRing;
 
   [NodePath("AnimatedSprite2D/LightOccluder2D")]
   public LightOccluder2D LightOccluder = null!;
@@ -141,22 +122,6 @@ public partial class Player : CharacterBody2D, IPersistent {
             _leftFaceNode,
             _rightFaceNode
         };
-
-    faceCollisionNodes = new List<CollisionShape2D>
-        {
-            FaceCollisionShapeB_node,
-            FaceCollisionShapeT_node,
-            FaceCollisionShapeL_node,
-            FaceCollisionShapeR_node
-        };
-
-    faceCornerCollisionNodes = new List<CollisionShape2D>
-        {
-            FaceCollisionShapeBR_node,
-            FaceCollisionShapeBL_node,
-            FaceCollisionShapeTL_node,
-            FaceCollisionShapeTR_node
-        };
   }
 
   public void OnResolved() {
@@ -174,7 +139,7 @@ public partial class Player : CharacterBody2D, IPersistent {
     InitSpriteAnimation();
     WasOnFloor = IsOnFloor();
     UpDirection = Vector2.Up;
-    InitFacesAreas();
+    InitColorAreas();
 
     _saveData = new SaveData(GlobalPosition.X, GlobalPosition.Y, 0f, 1f);
   }
@@ -193,18 +158,16 @@ public partial class Player : CharacterBody2D, IPersistent {
     PlayerRotationState?.Enter(this);
   }
 
-  private void InitFacesAreas() {
-    for (int i = 0; i < faceCollisionNodes.Count; i++) {
-      foreach (string grp in faceNodes[i].GetGroups()) {
-        faceCollisionNodes[i].AddToGroup(grp);
-      }
-    }
-
-    for (int i = 0; i < faceCornerCollisionNodes.Count; i++) {
-      foreach (string grp in faceSeparatorNodes[i].GetGroups()) {
-        faceCornerCollisionNodes[i].AddToGroup(grp);
-      }
-    }
+  private void InitColorAreas() {
+    var corner = faceSeparatorNodes[0];
+    _colorRing = new PlayerBox.Ring(
+      CornerOuterEdge: corner.OuterReach,
+      RestingCornerSide: corner.EdgeLength,
+      Overlap: (faceNodes[0].EdgeLength * 0.5f) - (corner.OuterReach - corner.EdgeLength)
+    );
+    // Lays the areas out where they were authored, and seeds the seam every color query reads.
+    // Not through ScaleCornersBy, which short-circuits on the factor it already holds.
+    _layOutColorAreas(_currentScaleFactor);
 
     _fillFaceNodesBackup();
     _fillFaceSeparatorsBackup();
@@ -345,91 +308,67 @@ public partial class Player : CharacterBody2D, IPersistent {
     }
   }
 
-  private void _scaleFaceSeparatorsBy(float factor) {
-    foreach (var face_sep in faceSeparatorNodes) {
-      face_sep.ScaleBy(factor);
-    }
-  }
-
-  private void _scaleFacesBy(float factor) {
-    foreach (var face_sep in faceNodes) {
-      face_sep.ScaleBy(factor);
-    }
-  }
+  // How forgiving the corners are, in the cube's own units: the seam reaches this far back along
+  // each of the two faces it joins. The color areas are laid out from it and every color query
+  // reads it, so a contact is judged the same wherever it came from.
+  public float CornerSeam { get; private set; }
 
   public void ScaleCornersBy(float factor) {
     if (_currentScaleFactor == factor)
       return;
     _currentScaleFactor = factor;
-    var edge = faceSeparatorNodes[0].EdgeLength;
-    var face = faceNodes[0].EdgeLength;
-    var total_length = 2 * edge + face;
-    var reverse_factor = (total_length - 2f * edge * factor) / face;
-    _scaleFaceSeparatorsBy(factor);
-    _scaleFacesBy(reverse_factor);
+    _layOutColorAreas(factor);
   }
 
-  public Vector2 GetCollisionShapeSize() {
-    var extra_w = (FaceCollisionShapeL_node.Shape as RectangleShape2D)?.Size.X ?? 0f;
-    return (((_collisionShapeNode.Shape as RectangleShape2D)?.Size ?? Vector2.Zero) * 0.5f + 2.0f * new Vector2(extra_w, extra_w)) * 2.0f;
+  // The corner squares grow about their pinned outer corners and the faces give way to meet
+  // them. Only the extent along each edge moves: face thickness is what decides how deep a
+  // contact must be before it registers at all, and dragging it along with the corner tolerance
+  // made flat-face contacts harder to detect exactly when corners were made easier.
+  private void _layOutColorAreas(float factor) {
+    var half = CollisionHalfExtentsLocal;
+    CornerSeam = PlayerBox.ClampSeam(_colorRing.SeamFor(factor, half.X), half);
+
+    var faceHalfLength = _colorRing.FaceHalfLengthFor(CornerSeam, half.X);
+    foreach (var corner in faceSeparatorNodes) {
+      corner.SetSeamSide(_colorRing.CornerSideFor(faceHalfLength));
+    }
+    foreach (var face in faceNodes) {
+      face.SetEdgeLength(faceHalfLength * 2.0f);
+    }
   }
 
-  // The cube's outer surface in world units - the hull plus the colored plates standing proud
-  // of it, which is what anything bouncing off the cube actually meets. GetCollisionShapeSize
-  // adds the plates twice over and so reports a cube noticeably larger than the one on screen.
-  public Vector2 GetCollisionHalfExtents() {
-    var plate = ((FaceCollisionShapeR_node.Shape as RectangleShape2D)?.Size.X ?? 0f) * 0.5f;
-    return new Vector2(
-      Mathf.Abs(FaceCollisionShapeR_node.Position.X) + plate,
-      Mathf.Abs(FaceCollisionShapeB_node.Position.Y) + plate
-    ) * GlobalScale.Abs();
-  }
+  // The cube's outer surface, in its own units and in world units. One rectangle, which is what
+  // anything bouncing off the cube, probing the ground under it or framing it in the camera
+  // measures itself against.
+  public Vector2 CollisionHalfExtentsLocal =>
+    ((_collisionShapeNode.Shape as RectangleShape2D)?.Size ?? Vector2.Zero) * 0.5f;
+
+  public Vector2 GetCollisionHalfExtents() => CollisionHalfExtentsLocal * GlobalScale.Abs();
 
   // Whether the cube survives touching `colorGroup` at a point on its surface. A point out near
   // a corner lies on the seam two faces share and either of their colors is safe there, which
   // is what the corner separators are for - and why widening them, as the brick breaker does,
   // makes the cube more forgiving to play.
-  public bool AcceptsColorAt(Vector2 globalPoint, string colorGroup) {
-    var half = GetCollisionHalfExtents();
-    var seam = _cornerSeamReach();
-    var local = (globalPoint - GlobalPosition).Rotated(-GlobalRotation);
+  public bool AcceptsColorAt(Vector2 globalPoint, string colorGroup) =>
+    _acceptsAt(globalPoint, face => face.AcceptsColor(colorGroup));
 
-    var onSide = Mathf.Abs(local.X) >= half.X - seam;
-    var onEnd = Mathf.Abs(local.Y) >= half.Y - seam;
+  // The same question asked of an area that carries its color as a group, which is how every
+  // object the cube can touch is tagged.
+  public bool AcceptsColorOfAt(Vector2 globalPoint, Area2D area) =>
+    _acceptsAt(globalPoint, face => face.AcceptsColorOf(area));
 
-    if (onSide && (local.X >= 0.0f ? _rightFaceNode : _leftFaceNode).AcceptsColor(colorGroup)) {
-      return true;
-    }
-    if (onEnd && (local.Y >= 0.0f ? _bottomFaceNode : _topFaceNode).AcceptsColor(colorGroup)) {
-      return true;
-    }
+  private bool _acceptsAt(Vector2 globalPoint, Func<BoxFace, bool> accepts) {
+    var box = new PlayerBox(GetCollisionHalfExtents(), CornerSeam * Mathf.Abs(GlobalScale.X));
+    var faces = box.FacesAt((globalPoint - GlobalPosition).Rotated(-GlobalRotation));
+
     // A point that belongs to no face at all is not one this cube has an opinion about.
-    return !onSide && !onEnd;
-  }
-
-  // How far a corner separator reaches along each of the two faces it joins.
-  private float _cornerSeamReach() =>
-    _faceSeparatorBR_node.EdgeLength * _faceSeparatorBR_node.Scale.X * GlobalScale.X * 0.5f;
-
-  // This function is a hack for bullets and fast moving objects because of this Godot issue:
-  // https://github.com/godotengine/godot/issues/43743
-  //
-  public void OnFastAreaCollidingWithPlayerShape(uint bodyShapeIndex, Area2D colorArea, EntityType entityType) {
-    var collisionShape = (CollisionShape2D)ShapeOwnerGetOwner(bodyShapeIndex);
-    var shapeGroups = collisionShape.GetGroups();
-    if (shapeGroups.Count == 0) {
-      return;
+    if (faces == PlayerBox.Faces.None) {
+      return true;
     }
-    var groupFound = false;
-    foreach (string group in shapeGroups) {
-      if (colorArea.IsInGroup(group)) {
-        groupFound = true;
-        break;
-      }
-    }
-    if (!groupFound) {
-      EventHandler.Instance.EmitPlayerDying(colorArea, GlobalPosition, entityType);
-    }
+    return (faces.HasFlag(PlayerBox.Faces.Right) && accepts(_rightFaceNode))
+      || (faces.HasFlag(PlayerBox.Faces.Left) && accepts(_leftFaceNode))
+      || (faces.HasFlag(PlayerBox.Faces.Bottom) && accepts(_bottomFaceNode))
+      || (faces.HasFlag(PlayerBox.Faces.Top) && accepts(_topFaceNode));
   }
 
   // Face areas backup
@@ -482,12 +421,6 @@ public partial class Player : CharacterBody2D, IPersistent {
   }
 
   private void _setCollisionShapesDisabledFlag(bool disable) {
-    foreach (var face in faceCollisionNodes) {
-      face.Disabled = disable;
-    }
-    foreach (var face in faceCornerCollisionNodes) {
-      face.Disabled = disable;
-    }
     _collisionShapeNode.Disabled = disable;
   }
 

--- a/src/Wfc/Entities/World/Player/Player/Player.tscn
+++ b/src/Wfc/Entities/World/Player/Player/Player.tscn
@@ -1,11 +1,9 @@
-[gd_scene load_steps=12 format=3 uid="uid://nvn44bv2puaj"]
+[gd_scene load_steps=10 format=3 uid="uid://nvn44bv2puaj"]
 
 [ext_resource type="SpriteFrames" path="res://Assets/Animations/player_frames.tres" id="1"]
 [ext_resource type="Script" uid="uid://btfa8iyy5gce2" path="res://src/Wfc/Entities/World/Player/Player/Player.cs" id="2"]
 [ext_resource type="PackedScene" uid="uid://bcrcp4q2theea" path="res://src/Wfc/Entities/World/Player/Face/BoxFace/BoxFace.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://byaynnxa1dwb6" path="res://src/Wfc/Entities/World/Player/Face/BoxCorner/FaceSeparator.tscn" id="4"]
-[ext_resource type="PackedScene" uid="uid://l65bdg6xvfrs" path="res://src/Wfc/Entities/World/Player/Face/BoxFace/FaceCollisionShape.tscn" id="5"]
-[ext_resource type="PackedScene" uid="uid://c7s2e6euryym8" path="res://src/Wfc/Entities/World/Player/Face/BoxCorner/CornerCollisionShape.tscn" id="6"]
 
 [sub_resource type="Curve" id="6"]
 _limits = [0.0, 45.0, 0.0, 1.0]
@@ -24,11 +22,11 @@ colors = PackedColorArray(1, 1, 1, 0.454902, 1, 1, 1, 0.113725)
 polygon = PackedVector2Array(-47, -47, 47, -47, 47, 47, -47, 47)
 
 [sub_resource type="RectangleShape2D" id="1"]
-size = Vector2(87, 87)
+size = Vector2(95.4, 95.4)
 
 [node name="Player" type="CharacterBody2D" groups=["persist"]]
 collision_layer = 2
-collision_mask = 1485
+collision_mask = 1157
 floor_stop_on_slope = false
 floor_max_angle = 0.113446
 script = ExtResource("2")
@@ -90,29 +88,3 @@ wait_time = 1.5
 
 [node name="DashGhostTimer" type="Timer" parent="."]
 wait_time = 0.1
-
-[node name="FaceCollisionShapeL" parent="." instance=ExtResource("5")]
-position = Vector2(-45.7, 0)
-
-[node name="FaceCollisionShapeR" parent="." instance=ExtResource("5")]
-position = Vector2(45.7, 0)
-
-[node name="FaceCollisionShapeT" parent="." instance=ExtResource("5")]
-position = Vector2(0, -45.7)
-rotation = 1.5708
-
-[node name="FaceCollisionShapeB" parent="." instance=ExtResource("5")]
-position = Vector2(0, 45.7)
-rotation = 1.5708
-
-[node name="FaceCollisionShapeTL" parent="." instance=ExtResource("6")]
-position = Vector2(-45.7, -45.7)
-
-[node name="FaceCollisionShapeBL" parent="." instance=ExtResource("6")]
-position = Vector2(-45.7, 45.7)
-
-[node name="FaceCollisionShapeTR" parent="." instance=ExtResource("6")]
-position = Vector2(45.7, -45.7)
-
-[node name="FaceCollisionShapeBR" parent="." instance=ExtResource("6")]
-position = Vector2(45.7, 45.7)

--- a/src/Wfc/Entities/World/Player/PlayerBox/PlayerBox.cs
+++ b/src/Wfc/Entities/World/Player/PlayerBox/PlayerBox.cs
@@ -1,0 +1,58 @@
+namespace Wfc.Entities.World.Player;
+
+using System;
+using Godot;
+
+// The cube's colored surface as plain numbers, in the cube's own frame and centered on the
+// origin. Everything that has to decide which color the cube presents at a point asks this, so
+// the surface is partitioned once rather than once per collision partner.
+public readonly record struct PlayerBox(Vector2 HalfExtents, float CornerSeam) {
+  // Which faces answer for a point. A corner is a seam the two faces it joins share, so a
+  // contact there names both of them and either color is safe.
+  [Flags]
+  public enum Faces {
+    None = 0,
+    Right = 1,
+    Left = 2,
+    Bottom = 4,
+    Top = 8,
+  }
+
+  // No faces at all means the point reaches none of them - it is inside the cube, or off it
+  // altogether - which is not something the cube has an opinion about.
+  public Faces FacesAt(Vector2 localPoint) {
+    var faces = Faces.None;
+    if (Mathf.Abs(localPoint.X) >= HalfExtents.X - CornerSeam) {
+      faces |= localPoint.X >= 0.0f ? Faces.Right : Faces.Left;
+    }
+    if (Mathf.Abs(localPoint.Y) >= HalfExtents.Y - CornerSeam) {
+      faces |= localPoint.Y >= 0.0f ? Faces.Bottom : Faces.Top;
+    }
+    return faces;
+  }
+
+  // A seam deeper than the cube leaves the faces between the corners with negative length, which
+  // hands the color areas an inverted shape. The scale factor behind it is persisted in the
+  // player's save data, so the bound has to hold for values no caller ever passes.
+  public static float ClampSeam(float seam, Vector2 halfExtents) =>
+    Mathf.Clamp(seam, 0.0f, Mathf.Min(halfExtents.X, halfExtents.Y));
+
+  // How the color areas tile the perimeter: four corner squares, each pinned by its outer
+  // corner so that widening a seam never changes the cube's silhouette, and four faces filling
+  // what is left between them. `Overlap` is how far a face reaches past the join, which is what
+  // stops a gap opening between the two for a contact to fall through.
+  public readonly record struct Ring(float CornerOuterEdge, float RestingCornerSide, float Overlap) {
+    private float RestingFaceHalfLength => CornerOuterEdge - RestingCornerSide + Overlap;
+
+    public float RestingSeam(float halfExtent) => halfExtent - RestingFaceHalfLength;
+
+    // Widening a corner square by `factor` about its pinned outer corner pushes the seam that
+    // much further back along each of the two faces it joins.
+    public float SeamFor(float factor, float halfExtent) =>
+      RestingSeam(halfExtent) + (RestingCornerSide * (factor - 1.0f));
+
+    public float FaceHalfLengthFor(float seam, float halfExtent) => halfExtent - seam;
+
+    public float CornerSideFor(float faceHalfLength) => CornerOuterEdge + Overlap - faceHalfLength;
+  }
+}

--- a/src/Wfc/Entities/World/Player/PlayerBox/PlayerBox.cs.uid
+++ b/src/Wfc/Entities/World/Player/PlayerBox/PlayerBox.cs.uid
@@ -1,0 +1,1 @@
+uid://dhgnbbt8s7vsj

--- a/src/Wfc/Entities/World/Player/State/PlayerSlipperingState/PlayerSlipperingState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerSlipperingState/PlayerSlipperingState.cs
@@ -122,29 +122,39 @@ public partial class PlayerSlipperingState : PlayerBaseState {
     return null;
   }
 
+  // The cube's lower corner on the side `dir` points to, in the player's own frame. Which
+  // physical corner that is changes with every quarter turn, so it is measured rather than named.
+  //
+  // A cube resting on an exact diagonal has no corner that is both to one side and below, and the
+  // corner directly underneath is the one worth probing from.
   public Vector2 _getPlayerEdgePosition(Player player, int dir) {
+    var half = player.CollisionHalfExtentsLocal;
     var corners = new[] {
-      ( player.FaceCollisionShapeTL_node, new Vector2(-0.5f, -0.5f) ),
-      ( player.FaceCollisionShapeTR_node, new Vector2(0.5f, -0.5f) ),
-      ( player.FaceCollisionShapeBL_node, new Vector2(-0.5f, 0.5f) ),
-      ( player.FaceCollisionShapeBR_node, new Vector2(0.5f, 0.5f) )
+      new Vector2(-half.X, -half.Y),
+      new Vector2(half.X, -half.Y),
+      new Vector2(-half.X, half.Y),
+      new Vector2(half.X, half.Y)
     };
 
-    var pp = player.GlobalPosition;
-    var position = pp;
-    var size = player.GetCollisionShapeSize() * 0.5f * player.Scale;
-    var positionLocal = pp;
+    var center = player.GlobalPosition;
+    var toTheSide = Vector2.Zero;
+    var lowest = Vector2.Zero;
+    var toTheSideY = float.NegativeInfinity;
+    var lowestY = float.NegativeInfinity;
 
-    foreach (var (cc, offset) in corners) {
-      var cp = cc.GlobalPosition;
-      if (Mathf.Sign(pp.X - cp.X) == -dir && cp.Y > position.Y) {
-        position = cp;
-        size = (cc.Shape as RectangleShape2D)?.Size ?? Vector2.Zero;
-        positionLocal = cc.Position + offset * size * player.Scale;
-        return positionLocal;
+    foreach (var corner in corners) {
+      var global = player.ToGlobal(corner);
+      if (global.Y > lowestY) {
+        lowest = corner;
+        lowestY = global.Y;
+      }
+      if ((global.X - center.X) * dir > 0f && global.Y > center.Y && global.Y > toTheSideY) {
+        toTheSide = corner;
+        toTheSideY = global.Y;
       }
     }
-    return positionLocal;
+
+    return toTheSideY > float.NegativeInfinity ? toTheSide : lowest;
   }
 
   // This method is used to raycast a ray of one of the two players ground corners.

--- a/src/Wfc/Entities/World/Player/State/PlayerStandingState/PlayerStandingState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerStandingState/PlayerStandingState.cs
@@ -12,6 +12,16 @@ public partial class PlayerStandingState : PlayerBaseState {
   private const float RAYCAST_Y_OFFSET = -5.0f; // https://godotengine.org/qa/63336/raycast2d-doesnt-collide-with-tilemap
   private const float SLIPPERING_LIMIT = 0.42f; // higher is less slippering
 
+  // The probes are cast from a box a little larger than the cube, on both axes.
+  //
+  // That reads like a mistake and it used to be one: the size came from a hand-rolled sum that
+  // counted the cube's collision plates twice, so nothing in the scene was ever that big. But the
+  // slippering fixtures are tuned to where these rays land to within a pixel - narrow the box to
+  // the cube itself, on either axis, and a cube perched on a ledge catches its own edge and tips
+  // a second time instead of committing to the fall. So it stays, stated as what it actually is:
+  // a reach past the cube, and not a second opinion about how big the cube is.
+  private const float PROBE_REACH = 1.0796f;
+
   public PlayerStandingState(IPlayerStatesStore statesStore, IInputManager inputManager)
     : base(statesStore, inputManager) { }
 
@@ -43,21 +53,27 @@ public partial class PlayerStandingState : PlayerBaseState {
     return null;
   }
 
+  // The box the probes are cast from, given the cube's true half-extents.
+  internal static Vector2 ProbeBox(Vector2 halfExtents) => halfExtents * PROBE_REACH;
+
+  // Where the four probes sit across it. The result is read as a bit pattern, and only the two
+  // patterns meaning "one outer probe alone found floor" start a slip - so these positions are
+  // the whole of the mechanic.
+  internal static float[] FloorProbeOffsets(float halfWidth) {
+    var reach = halfWidth * PROBE_REACH;
+    return new[] { -reach, -reach * SLIPPERING_LIMIT, reach * SLIPPERING_LIMIT, reach };
+  }
+
   private PlayerSlipperingState? RaycastFloor(Player player) {
     var spaceState = player.GetWorld2D().DirectSpaceState;
-    var playerHalfSize = player.GetCollisionShapeSize() * 0.5f * player.Scale;
+    var half = player.GetCollisionHalfExtents();
+    var probeBox = ProbeBox(half);
 
     int combination = 0;
     int i = 1;
-    float[] fromOffsetX = {
-            -playerHalfSize.X,
-            -playerHalfSize.X * SLIPPERING_LIMIT,
-            playerHalfSize.X * SLIPPERING_LIMIT,
-            playerHalfSize.X
-        };
 
-    foreach (var offset in fromOffsetX) {
-      Vector2 from = player.GlobalPosition + new Vector2(offset, playerHalfSize.Y + RAYCAST_Y_OFFSET);
+    foreach (var offset in FloorProbeOffsets(half.X)) {
+      Vector2 from = player.GlobalPosition + new Vector2(offset, probeBox.Y + RAYCAST_Y_OFFSET);
       Vector2 to = from + new Vector2(0.0f, RAYCAST_LENGTH);
       var physicsRayQueryParameters = PhysicsRayQueryParameters2D.Create(
           from, to, exclude: new Godot.Collections.Array<Rid> { player.GetRid() }

--- a/test/Instrumented/src/BrickBreaker/BallPaddleBounceTests.cs
+++ b/test/Instrumented/src/BrickBreaker/BallPaddleBounceTests.cs
@@ -42,7 +42,7 @@ public class BallPaddleBounceTests(Node testScene) : TestClass(testScene) {
 
   private async Task _jumpIntoBall(float acrossFace) {
     var player = await _addPlayer();
-    var half = player.GetCollisionShapeSize() * 0.5f;
+    var half = player.GetCollisionHalfExtents();
 
     var ball = SceneHelpers.InstantiateNode<BouncingBall>();
     _provider.AddChild(ball);

--- a/test/Instrumented/src/Layer/PlayerLayersTests.cs
+++ b/test/Instrumented/src/Layer/PlayerLayersTests.cs
@@ -1,0 +1,135 @@
+namespace Wfc.test.instrumented;
+
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Utils.Layers;
+
+// Which layers the cube answers to, on the two nodes that answer for different things: the body,
+// which decides what the cube cannot walk through, and the color faces, which decide what kills
+// it. A mask edit that breaks one of these is invisible until someone plays the level it broke.
+//
+// Nothing is added to the tree - masks are scene data, and staying out keeps _Ready and the
+// dependencies it would want out of it.
+public class PlayerLayersTests(Node testScene) : TestClass(testScene) {
+  private const string PLAYER_SCENE = "res://src/Wfc/Entities/World/Player/Player/Player.tscn";
+  private const string POWER_UP_SCENE = "res://src/Wfc/Entities/World/BrickBreaker/Powerups/PowerUp/PowerUp.tscn";
+
+  private static readonly string[] FACE_NODES = {
+    "TopFace", "BottomFace", "LeftFace", "RightFace",
+    "FaceSeparatorTL", "FaceSeparatorTR", "FaceSeparatorBL", "FaceSeparatorBR"
+  };
+
+  // Everything the cube is allowed to be killed or landed on by. Each of these carries its color
+  // as a group and is judged by whichever face reaches it.
+  private static readonly (string Name, LayerInfo Layer)[] COLORED_PARTNERS = {
+    ("platforms", PhysicsLayers.Platform),
+    ("fall zones", PhysicsLayers.FallZone),
+    ("gems", PhysicsLayers.Gems),
+    ("bullets", PhysicsLayers.Bullets),
+    ("tetris blocks", PhysicsLayers.Tetris),
+    ("bricks", PhysicsLayers.Bricks),
+  };
+
+  [Test]
+  public void EveryColorFaceSeesEveryColoredThingItCanTouch() {
+    using var player = _load(PLAYER_SCENE);
+
+    foreach (var face in FACE_NODES) {
+      var area = player.GetNode<Area2D>(face);
+      area.CollisionLayer.ShouldBe(
+        PhysicsLayers.BoxFace.Mask,
+        $"{face} is off the face layer, so nothing that looks for a face finds it"
+      );
+      foreach (var (name, layer) in COLORED_PARTNERS) {
+        (area.CollisionMask & layer.Mask).ShouldBe(
+          layer.Mask,
+          $"{face} cannot see {name}, so touching one is neither fatal nor a landing"
+        );
+      }
+    }
+  }
+
+  // The lazer casts against the face layer to find out what color the cube is showing it, so a
+  // face off that layer leaves the beam shining through the player.
+  [Test]
+  public void TheFacesAreOnTheLayerTheLazerCastsAgainst() {
+    using var player = _load(PLAYER_SCENE);
+
+    foreach (var face in FACE_NODES) {
+      (player.GetNode<Area2D>(face).CollisionLayer & PhysicsLayers.BoxFace.Mask)
+        .ShouldBe(PhysicsLayers.BoxFace.Mask);
+    }
+  }
+
+  // A power-up is caught, not walked into. It used to carry a static body the cube alone could
+  // collide with, so an uncollected one - or one that arrived while the player was dying, which
+  // skipped the free - stood in the arena as an invisible wall.
+  [Test]
+  public void APowerUpIsNotSomethingTheCubeCanStandOn() {
+    using var player = _load(PLAYER_SCENE);
+    using var powerUp = _load<Node2D>(POWER_UP_SCENE);
+
+    (player.CollisionMask & PhysicsLayers.PowerUp.Mask)
+      .ShouldBe(0u, "a solid power-up is an obstacle in an arena that has no room for one");
+
+    foreach (var child in powerUp.GetChildren()) {
+      child.ShouldNotBeOfType<StaticBody2D>("nothing is left for the cube to collide with");
+    }
+  }
+
+  // And it is still caught: the pickup is the power-up's own area noticing the cube's body.
+  [Test]
+  public void APowerUpStillSeesTheCubeThatCatchesIt() {
+    using var player = _load(PLAYER_SCENE);
+    using var powerUp = _load<Node2D>(POWER_UP_SCENE);
+
+    (powerUp.GetNode<Area2D>("Area2D").CollisionMask & player.CollisionLayer)
+      .ShouldBe(player.CollisionLayer, "a power-up that cannot see the player can never be picked up");
+  }
+
+  // Fall zones and faces exist only as areas, so a body mask bit for either detects nothing and
+  // says nothing. Carrying them read as though the body took part in those contacts, which is the
+  // same misreading that left the cube solid against falling power-ups.
+  [Test]
+  public void TheCubesBodyDoesNotMaskLayersOnlyAreasLiveOn() {
+    using var player = _load(PLAYER_SCENE);
+    var areaOnly = PhysicsLayers.FallZone.Mask | PhysicsLayers.BoxFace.Mask;
+
+    (player.CollisionMask & areaOnly)
+      .ShouldBe(0u, "the color faces detect these; a body mask bit cannot detect anything");
+  }
+
+  // A bullet does have a body, and briefly stopped the cube dead on contact - it frees itself on
+  // touching the player, but freeing is deferred and the body is solid for the rest of the frame.
+  // Whether a bullet kills is the faces' business; it is never a wall.
+  [Test]
+  public void ABulletDoesNotBlockTheCube() {
+    using var player = _load(PLAYER_SCENE);
+
+    (player.CollisionMask & PhysicsLayers.Bullets.Mask)
+      .ShouldBe(0u, "a bullet the cube cannot walk through is a moving wall");
+  }
+
+  // Tetris blocks, by contrast, are bodies the cube is meant to stand on.
+  [Test]
+  public void TheCubeStillStandsOnTetrisBlocks() {
+    using var player = _load(PLAYER_SCENE);
+
+    (player.CollisionMask & PhysicsLayers.Tetris.Mask)
+      .ShouldBe(PhysicsLayers.Tetris.Mask, "the cube rides the falling blocks");
+  }
+
+  // The cube still has to stand on the world.
+  [Test]
+  public void TheCubeStillCollidesWithTheGround() {
+    using var player = _load(PLAYER_SCENE);
+    var ground = PhysicsLayers.Default.Mask | PhysicsLayers.Platform.Mask;
+
+    (player.CollisionMask & ground).ShouldBe(ground);
+  }
+
+  private static T _load<T>(string path) where T : Node => GD.Load<PackedScene>(path).Instantiate<T>();
+
+  private static CharacterBody2D _load(string path) => _load<CharacterBody2D>(path);
+}

--- a/test/Instrumented/src/Layer/PlayerLayersTests.cs.uid
+++ b/test/Instrumented/src/Layer/PlayerLayersTests.cs.uid
@@ -1,0 +1,1 @@
+uid://4b6qlm16b5gb

--- a/test/Instrumented/src/Player/PlayerCollisionGeometryTests.cs
+++ b/test/Instrumented/src/Player/PlayerCollisionGeometryTests.cs
@@ -1,0 +1,183 @@
+namespace Wfc.test.instrumented.Player;
+
+using System.Threading.Tasks;
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Entities.World.Player;
+using Wfc.test.instrumented.Helpers.Fakes;
+using Wfc.Utils.Colors;
+
+// The cube used to be five hand-maintained descriptions of itself, disagreeing about how wide it
+// is and about which color it shows where. Nothing reconciled them and nothing tested them, so
+// each was free to drift on its own. These pin the ones that matter to the scene.
+public class PlayerCollisionGeometryTests(Node testScene) : TestClass(testScene) {
+  private const float JUMPING_SCALE = 4.5f;
+  private const float A_LITTLE_WAY_IN = 6.0f;
+
+  private FakeDependenciesProvider _provider = default!;
+
+  [Setup]
+  public async Task Setup() {
+    _provider = new FakeDependenciesProvider();
+    TestScene.AddChild(_provider);
+    await _physicsFrame();
+  }
+
+  [Cleanup]
+  public void Cleanup() => _provider.QueueFree();
+
+  // One shape, so the half-extents are the surface rather than something derived from a hull and
+  // eight plates standing proud of it.
+  [Test]
+  public async Task TheCubeIsOneCollisionShapeAndTheHalfExtentsAreIt() {
+    var player = await _addPlayer();
+
+    var shapes = 0;
+    CollisionShape2D? only = null;
+    foreach (var child in player.GetChildren()) {
+      if (child is CollisionShape2D shape) {
+        shapes++;
+        only = shape;
+      }
+    }
+
+    shapes.ShouldBe(1, "the cube's surface is one rectangle");
+    var size = ((RectangleShape2D)only!.Shape).Size;
+    player.GetCollisionHalfExtents().X.ShouldBe(size.X * 0.5f, 0.001f);
+    player.GetCollisionHalfExtents().Y.ShouldBe(size.Y * 0.5f, 0.001f);
+  }
+
+  // The one that was silently orientation-dependent: the side faces never repositioned at all and
+  // the top and bottom overcompensated, so which color you had rotated to the floor changed how
+  // deep a landing had to be. The core verb of the game is rotating the cube, so this is a
+  // difference the player feels without ever being able to name it.
+  [Test]
+  public async Task GrowingTheCornersLeavesEveryFaceWhereItWas() {
+    var player = await _addPlayer();
+    var before = _faceOuterEdges(player);
+
+    player.ScaleCornersBy(JUMPING_SCALE);
+
+    var after = _faceOuterEdges(player);
+    for (var i = 0; i < before.Length; i++) {
+      after[i].ShouldBe(before[i], 0.001f, "a face moved when the corners grew");
+    }
+  }
+
+  [Test]
+  public async Task EveryFaceSitsTheSameDistanceOut() {
+    var player = await _addPlayer();
+    player.ScaleCornersBy(JUMPING_SCALE);
+
+    var edges = _faceOuterEdges(player);
+    foreach (var edge in edges) {
+      edge.ShouldBe(edges[0], 0.001f, "the cube's color band is lopsided");
+    }
+  }
+
+  // Thickness is how deep a contact must be before it registers. Dragging it along with the corner
+  // tolerance made flat-face contacts harder to detect exactly when corners were made easier -
+  // and dropped the side faces behind the cube's own surface, where nothing could reach them.
+  [Test]
+  public async Task GrowingTheCornersLeavesTheFacesAsThickAsTheyWere() {
+    var player = await _addPlayer();
+    var before = _faceThickness(player);
+
+    player.ScaleCornersBy(JUMPING_SCALE);
+
+    _faceThickness(player).ShouldBe(before, 0.001f);
+  }
+
+  [Test]
+  public async Task TheColorBandStandsProudOfTheCubesSurface() {
+    var player = await _addPlayer();
+    player.ScaleCornersBy(JUMPING_SCALE);
+
+    foreach (var edge in _faceOuterEdges(player)) {
+      edge.ShouldBeGreaterThan(
+        player.GetCollisionHalfExtents().X,
+        "a color band inside the surface can never be reached by a body resting against it"
+      );
+    }
+  }
+
+  // What the corner scaling exists to provide, now expressed as one number the analytic query and
+  // the color areas both read. Bullets were judged against the unscaled body shapes and so never
+  // saw any of it.
+  [Test]
+  public async Task AWiderSeamForgivesFurtherFromTheCorner() {
+    var player = await _addPlayer();
+    var half = player.GetCollisionHalfExtents();
+    var nearTheBottomRight = player.GlobalPosition + new Vector2(half.X - A_LITTLE_WAY_IN, half.Y);
+
+    player.AcceptsColorAt(nearTheBottomRight, ColorUtils.PURPLE)
+      .ShouldBeTrue("the bottom face's own color is safe on the bottom face");
+    player.AcceptsColorAt(nearTheBottomRight, ColorUtils.YELLOW)
+      .ShouldBeFalse("at rest this is not near enough the corner to be a seam");
+
+    player.ScaleCornersBy(JUMPING_SCALE);
+
+    player.AcceptsColorAt(nearTheBottomRight, ColorUtils.YELLOW)
+      .ShouldBeTrue("a widened seam has to reach this contact for anything to have been forgiven");
+  }
+
+  [Test]
+  public async Task TheSeamWidensWithTheScaleFactor() {
+    var player = await _addPlayer();
+    var atRest = player.CornerSeam;
+
+    player.ScaleCornersBy(JUMPING_SCALE);
+
+    player.CornerSeam.ShouldBeGreaterThan(atRest);
+  }
+
+  // Reachable from save data, where the scale factor is persisted.
+  [Test]
+  public async Task AnAbsurdScaleFactorDoesNotInvertTheFaces() {
+    var player = await _addPlayer();
+
+    player.ScaleCornersBy(1000f);
+
+    player.CornerSeam.ShouldBeLessThanOrEqualTo(player.CollisionHalfExtentsLocal.X);
+    foreach (var face in _faces(player)) {
+      _shapeOf(face).Size.X.ShouldBeGreaterThanOrEqualTo(0f, "an inverted face area collides with nothing");
+    }
+  }
+
+  private static float[] _faceOuterEdges(Wfc.Entities.World.Player.Player player) {
+    var faces = _faces(player);
+    var edges = new float[faces.Length];
+    for (var i = 0; i < faces.Length; i++) {
+      edges[i] = faces[i].Position.Length() + (_shapeOf(faces[i]).Size.Y * 0.5f);
+    }
+    return edges;
+  }
+
+  private static float _faceThickness(Wfc.Entities.World.Player.Player player) =>
+    _shapeOf(_faces(player)[0]).Size.Y;
+
+  private static BoxFace[] _faces(Wfc.Entities.World.Player.Player player) => new[] {
+    player.GetNode<BoxFace>("BottomFace"),
+    player.GetNode<BoxFace>("TopFace"),
+    player.GetNode<BoxFace>("LeftFace"),
+    player.GetNode<BoxFace>("RightFace")
+  };
+
+  private static RectangleShape2D _shapeOf(Node2D face) =>
+    (RectangleShape2D)face.GetNode<CollisionShape2D>("CollisionShape2D").Shape;
+
+  private async Task<Wfc.Entities.World.Player.Player> _addPlayer() {
+    var player = GD.Load<PackedScene>("res://src/Wfc/Entities/World/Player/Player/Player.tscn")
+      .Instantiate<Wfc.Entities.World.Player.Player>();
+    _provider.AddChild(player);
+    await _physicsFrame();
+    player.SetPhysicsProcess(false);
+    return player;
+  }
+
+  private async Task _physicsFrame() {
+    var tree = TestScene.GetTree();
+    await tree.ToSignal(tree, SceneTree.SignalName.PhysicsFrame);
+  }
+}

--- a/test/Instrumented/src/Player/PlayerCollisionGeometryTests.cs.uid
+++ b/test/Instrumented/src/Player/PlayerCollisionGeometryTests.cs.uid
@@ -1,0 +1,1 @@
+uid://d7c1lcpjrgq8

--- a/test/src/Wfc/Entities/World/Player/PlayerBox/PlayerBoxTests.cs
+++ b/test/src/Wfc/Entities/World/Player/PlayerBox/PlayerBoxTests.cs
@@ -1,0 +1,96 @@
+namespace Wfc.Entities.World.Player.Test;
+
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Entities.World.Player;
+
+// The one partition of the cube's surface. It used to be answered three different ways - off the
+// color areas, off the body shapes, and analytically - and the three disagreed by up to three and
+// a half times over exactly the region the corners exist to forgive.
+public class PlayerBoxTests(Node testScene) : TestClass(testScene) {
+  private static readonly Vector2 HALF = new Vector2(50f, 50f);
+  private const float SEAM = 10f;
+
+  private static PlayerBox _box(float seam = SEAM) => new PlayerBox(HALF, seam);
+
+  [Test]
+  public void TheMiddleOfAFaceNamesThatFaceAlone() {
+    _box().FacesAt(new Vector2(0f, 50f)).ShouldBe(PlayerBox.Faces.Bottom);
+    _box().FacesAt(new Vector2(0f, -50f)).ShouldBe(PlayerBox.Faces.Top);
+    _box().FacesAt(new Vector2(50f, 0f)).ShouldBe(PlayerBox.Faces.Right);
+    _box().FacesAt(new Vector2(-50f, 0f)).ShouldBe(PlayerBox.Faces.Left);
+  }
+
+  // The whole point of a corner: a contact on the seam is answered by both faces that meet
+  // there, so either of their colors is survivable.
+  [Test]
+  public void AContactWithinTheSeamNamesBothFacesThatMeetThere() {
+    _box().FacesAt(new Vector2(45f, 50f)).ShouldBe(PlayerBox.Faces.Right | PlayerBox.Faces.Bottom);
+    _box().FacesAt(new Vector2(-45f, -50f)).ShouldBe(PlayerBox.Faces.Left | PlayerBox.Faces.Top);
+  }
+
+  [Test]
+  public void JustInsideTheSeamNamesOnlyTheFaceItLandedOn() {
+    _box().FacesAt(new Vector2(39f, 50f)).ShouldBe(PlayerBox.Faces.Bottom);
+  }
+
+  // Widening the seam is the whole of what "the corners are more forgiving now" means, and this
+  // number is the only thing that says so. Nothing moves, nothing is rescaled.
+  [Test]
+  public void AWiderSeamForgivesFurtherFromTheCorner() {
+    _box(seam: 5f).FacesAt(new Vector2(43f, 50f)).ShouldBe(PlayerBox.Faces.Bottom);
+    _box(seam: 20f).FacesAt(new Vector2(43f, 50f)).ShouldBe(PlayerBox.Faces.Right | PlayerBox.Faces.Bottom);
+  }
+
+  // Inside the cube there is no surface and so no color. Callers read None as "nothing here has
+  // an opinion", which is what keeps a ball that has climbed inside from being judged by whichever
+  // face it happens to be nearest.
+  [Test]
+  public void APointInsideTheCubeNamesNoFace() {
+    _box().FacesAt(Vector2.Zero).ShouldBe(PlayerBox.Faces.None);
+  }
+
+  // A contact is reported from wherever the other object's own geometry puts it, which is usually
+  // outside the cube rather than exactly on it.
+  [Test]
+  public void APointOutsideTheCubeStillNamesTheFaceItIsOff() {
+    _box().FacesAt(new Vector2(0f, 200f)).ShouldBe(PlayerBox.Faces.Bottom);
+  }
+
+  // The scale factor behind the seam is persisted in the player's save data, so the bound has to
+  // hold for values no caller ever passes.
+  [Test]
+  public void ASeamCannotEatTheWholeCube() {
+    PlayerBox.ClampSeam(1000f, HALF).ShouldBe(50f);
+    PlayerBox.ClampSeam(-1f, HALF).ShouldBe(0f);
+  }
+
+  // The corner squares grow about their pinned outer corners and the faces give way to meet them,
+  // so how forgiving the seam is never changes where the cube's surface is.
+  [Test]
+  public void GrowingTheCornersLeavesTheOuterEdgeWhereItWas() {
+    var ring = new PlayerBox.Ring(CornerOuterEdge: 48f, RestingCornerSide: 3f, Overlap: 0f);
+    var seam = ring.SeamFor(4f, 47f);
+    var faceHalfLength = ring.FaceHalfLengthFor(seam, 47f);
+    var cornerSide = ring.CornerSideFor(faceHalfLength);
+
+    cornerSide.ShouldBe(ring.RestingCornerSide * 4f, 0.001f);
+    (faceHalfLength + cornerSide).ShouldBe(ring.CornerOuterEdge, 0.001f);
+  }
+
+  // The faces overlap the corners rather than abutting them, which is what stops a contact
+  // falling between the two as the seam widens.
+  [Test]
+  public void TheFacesMeetTheCornersWithoutOpeningAGap() {
+    var ring = new PlayerBox.Ring(CornerOuterEdge: 48f, RestingCornerSide: 3f, Overlap: 0.1f);
+
+    foreach (var factor in new[] { 1f, 3.5f, 4.5f, 10f }) {
+      var seam = ring.SeamFor(factor, 47f);
+      var faceHalfLength = ring.FaceHalfLengthFor(seam, 47f);
+      var cornerInnerEdge = ring.CornerOuterEdge - ring.CornerSideFor(faceHalfLength);
+
+      faceHalfLength.ShouldBeGreaterThan(cornerInnerEdge, $"a gap opens at scale {factor}");
+    }
+  }
+}

--- a/test/src/Wfc/Entities/World/Player/PlayerBox/PlayerBoxTests.cs.uid
+++ b/test/src/Wfc/Entities/World/Player/PlayerBox/PlayerBoxTests.cs.uid
@@ -1,0 +1,1 @@
+uid://b1ji5s4te6wml

--- a/test/src/Wfc/Entities/World/Player/State/PlayerFloorProbeTests.cs
+++ b/test/src/Wfc/Entities/World/Player/State/PlayerFloorProbeTests.cs
@@ -1,0 +1,83 @@
+namespace Wfc.Entities.World.Player.Test;
+
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Entities.World.Player;
+
+// What decides whether the cube tips off a ledge. The four probes are read as a bit pattern, and
+// only the two patterns meaning "one outer probe alone found floor" start a slip, so where they sit
+// is the whole of the mechanic.
+//
+// They are cast from a box slightly larger than the cube. That used to be an accident - a size that
+// counted the cube's collision plates twice - and it is now deliberate, because the slippering
+// fixtures are tuned to it: narrowing the box to the cube on either axis makes a cube perched on a
+// ledge tip twice instead of once. These pin the reach so it cannot drift back by accident.
+public class PlayerFloorProbeTests(Node testScene) : TestClass(testScene) {
+  private const float HALF_WIDTH = 47.7f;
+  private static readonly Vector2 HALF = new Vector2(HALF_WIDTH, HALF_WIDTH);
+
+  [Test]
+  public void TheProbesReachPastTheCubeOnPurpose() {
+    var offsets = PlayerStandingState.FloorProbeOffsets(HALF_WIDTH);
+
+    offsets[^1].ShouldBeGreaterThan(
+      HALF_WIDTH,
+      "the outer probes reach past the cube; pulled back onto it, a perched cube tips twice"
+    );
+  }
+
+  // Both axes, and by the same amount. The vertical reach is what lets a probe still find the
+  // ledge a tipping cube is coming off, and it is as load-bearing as the horizontal one.
+  [Test]
+  public void TheProbeBoxReachesPastTheCubeOnBothAxes() {
+    var box = PlayerStandingState.ProbeBox(HALF);
+
+    box.X.ShouldBeGreaterThan(HALF.X);
+    box.Y.ShouldBeGreaterThan(HALF.Y);
+    (box.X / HALF.X).ShouldBe(box.Y / HALF.Y, 0.0001f, "the reach is not meant to be axis-dependent");
+  }
+
+  // It is a tolerance, not a measurement, so it stays modest. A box far larger than the cube
+  // samples ground the cube has nothing to do with.
+  [Test]
+  public void TheReachStaysCloseToTheCube() {
+    var box = PlayerStandingState.ProbeBox(HALF);
+
+    (box.X / HALF.X).ShouldBeLessThan(1.15f, "the probe box is a tolerance, not a second cube");
+  }
+
+  // Left to right, and symmetric about the middle: the bit pattern names a side, so a probe out of
+  // order would report a slip in the wrong direction.
+  [Test]
+  public void TheProbesRunOutsideInAndAreSymmetric() {
+    var offsets = PlayerStandingState.FloorProbeOffsets(HALF_WIDTH);
+
+    offsets.Length.ShouldBe(4);
+    offsets[0].ShouldBeLessThan(offsets[1]);
+    offsets[1].ShouldBeLessThan(offsets[2]);
+    offsets[2].ShouldBeLessThan(offsets[3]);
+    offsets[0].ShouldBe(-offsets[3], 0.0001f);
+    offsets[1].ShouldBe(-offsets[2], 0.0001f);
+  }
+
+  // The inner pair are what separate "overhanging a little" from "barely on at all". They have to
+  // stay well inside the outer pair or every landing near an edge reads as a slip.
+  [Test]
+  public void TheInnerProbesSitWellInsideTheOuterOnes() {
+    var offsets = PlayerStandingState.FloorProbeOffsets(HALF_WIDTH);
+
+    Mathf.Abs(offsets[1]).ShouldBeLessThan(Mathf.Abs(offsets[0]) * 0.6f);
+    Mathf.Abs(offsets[1]).ShouldBeGreaterThan(Mathf.Abs(offsets[0]) * 0.3f);
+  }
+
+  // Scaled by a power-up, the probes have to scale with the cube rather than staying where the
+  // full-sized one had them.
+  [Test]
+  public void TheProbesFollowTheCubeWhenItIsScaled() {
+    var full = PlayerStandingState.FloorProbeOffsets(HALF_WIDTH);
+    var shrunk = PlayerStandingState.FloorProbeOffsets(HALF_WIDTH * 0.7f);
+
+    shrunk[^1].ShouldBe(full[^1] * 0.7f, 0.0001f);
+  }
+}

--- a/test/src/Wfc/Entities/World/Player/State/PlayerFloorProbeTests.cs.uid
+++ b/test/src/Wfc/Entities/World/Player/State/PlayerFloorProbeTests.cs.uid
@@ -1,0 +1,1 @@
+uid://df0qh4aj54n3s


### PR DESCRIPTION
Scope: the player cube's collision system end to end — the CharacterBody2D hull, the eight body shapes, the eight color areas, the corner-scaling machinery, rotation, and every object the cube can touch. 

Proposed target design
Principle: one geometric description of the cube, one color query, and forgiveness expressed as a number rather than as node geometry.

Step 1 — One color query (highest value, lowest risk)
Make Player.AcceptsColorAt(globalPoint, colorGroup) the single authority, and route everything through it.

Bullet → replace OnFastAreaCollidingWithPlayerShape(bodyShapeIndex, …) with AcceptsColorAt(bulletGlobalPosition, bulletColorGroup). Fixes P6 outright.
Once no caller reads groups off body shapes, delete the group-copying loop in InitFacesAreas() — the second color system stops existing.
LazerBeam already has its hit position; switching it to the point query makes the seam width identical to every other consumer.
BoxFace / BoxCorner._onAreaEntered keep doing detection (Godot gives you the face identity for free and does the broad-phase), but delegate the verdict to AcceptsColorAt.
Step 2 — Forgiveness becomes a number
Today "how forgiving is a corner" is encoded by physically resizing and repositioning eight nodes with two different — both slightly wrong — formulas. Replace with a single CornerSeam float that ScaleCornersBy sets and AcceptsColorAt reads. No node moves, no node rescales.

This deletes BaseFace.ScaleBy, BoxFace.ScaleBy, and the reverse_factor arithmetic, and with them P1, P2, P3, P4, P7 and P8 simultaneously — they are all artifacts of moving geometry to express a tolerance.

Caveat worth naming: the areas must still be large enough to detect contact. Keeping them at their authoring size (scale 1) is the natural choice, since at scale 1 all four faces already agree (48.025) and sit just proud of the body surface (47.7), which is exactly the overlap detection needs.

Step 3 — One dimension
Introduce a small pure type — PlayerBox { Vector2 HalfExtents; float CornerSeam; Face FaceAt(Vector2 localPoint); } — living in test/src-testable code with no Node dependency, mirroring what BoxContact already does for the ball. Then:

GetCollisionShapeSize() → HalfExtents * 2f (or delete it in favour of the half-extents).
Retune SLIPPERING_LIMIT 0.42 → ≈0.4534 to hold current behavior, then decide separately whether today's behavior is wanted, given the probes have been outside the cube all along.
Leave RAYCAST_Y_OFFSET = -5; against the true bottom face it finally means what its linked issue intended.
Delete the dead size assignment in _getPlayerEdgePosition.
Step 4 (optional, larger) — One body shape
With color off the body shapes, the nine shapes can collapse to a single 95.4 × 95.4 rectangle. That removes the hull/plate seam, removes eight shapes from every physics query, and makes HalfExtents literally the shape rather than a derived value.

Blockers to handle first: PlayerSlipperingState._getPlayerEdgePosition and Explosion read the corner shape nodes; both would need corner positions computed from HalfExtents instead. Mechanical, but it is why this is step 4 and not step 1.

Step 5 — Layer hygiene
Trim Player.tscn's mask: drop PowerUp (256) (P9), and drop the inert FallZone (8) / Bullets (64) body bits. Extend the existing layer-reciprocity tests in BallPaddleLayersTests to cover face↔platform, face↔gem, face↔brick, face↔tetris and player↔power-up, so the next mask edit fails a test instead of a playtest.