### PR TITLE
Fix power up issue

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -159,6 +159,7 @@
     "reparents",
     "reparented",
     "recognisably",
+    "Respawning",
     "autoloaded",
     "autoloads",
     "ultrawide",

--- a/src/Wfc/Entities/World/BrickBreaker/BrickBreaker/BrickBreaker.cs
+++ b/src/Wfc/Entities/World/BrickBreaker/BrickBreaker/BrickBreaker.cs
@@ -12,6 +12,7 @@ using Wfc.Core.Serialization;
 using Wfc.Entities.World;
 using Wfc.Entities.World.BrickBreaker.Powerups;
 using Wfc.Entities.World.Camera;
+using Wfc.Entities.World.Checkpoints;
 using Wfc.Entities.World.Platforms;
 using Wfc.Screens.Levels;
 using Wfc.Utils;
@@ -49,7 +50,7 @@ public partial class BrickBreaker : Node2D, IPersistent {
   [NodePath("BricksContainer/BrickPowerUpHandler")]
   private IPowerUpHandler _bricksPowerUpHandler = default!;
   [NodePath("CheckpointArea")]
-  private Area2D _checkpointNode = default!;
+  private CheckpointArea _checkpointNode = default!;
   [NodePath("TriggerEnterArea")]
   private Area2D? _triggerEnterAreaNode = default!;
   [NodePath("SlidingFloor")]
@@ -220,7 +221,9 @@ public partial class BrickBreaker : Node2D, IPersistent {
   private void _onTriggerEnterAreaBodyEntered(Node body) {
     if (body != GameLevel.PlayerNode)
       return;
-    if (_currentState == BrickBreakerState.STOPPED) {
+    var isStarting = _currentState == BrickBreakerState.STOPPED;
+    if (isStarting) {
+      _currentState = BrickBreakerState.INIT_PLAYING;
       CallDeferred(nameof(Play));
       _slidingFloorSliderNode.SetLooping(false);
       _slidingFloorSliderNode.StopSlider(false);
@@ -236,6 +239,15 @@ public partial class BrickBreaker : Node2D, IPersistent {
     if (_triggerEnterAreaNode != null) {
       _triggerEnterAreaNode.QueueFree();
       _triggerEnterAreaNode = null;
+    }
+
+    if (isStarting) {
+      // The arena's checkpoint sits below this trigger, so the lift carries the player across it
+      // first, and everything it saved describes a room that had not been entered yet: a stopped
+      // arena, a lift still on its loop and the level's own music. Dying in here then restored a
+      // room with no game in it and no trigger left to start one. Record it again now that the
+      // arena is running.
+      EventHandler.Instance.EmitCheckpointReached(_checkpointNode.GlobalPosition, _checkpointNode.ColorGroup);
     }
   }
 

--- a/src/Wfc/Entities/World/BrickBreaker/Powerups/PlayerScalePowerUp/PlayerScalePowerUp.cs
+++ b/src/Wfc/Entities/World/BrickBreaker/Powerups/PlayerScalePowerUp/PlayerScalePowerUp.cs
@@ -1,0 +1,58 @@
+namespace Wfc.Entities.World.BrickBreaker.Powerups;
+
+using Godot;
+
+// Both scale power-ups drive the same value on the player, so which of them is entitled to hand it
+// back cannot be read off that value: for as long as a tween runs it matches neither one's target.
+// Whichever power-up last started a tween owns the scale, until another takes it or it gives it back.
+public abstract partial class PlayerScalePowerUp : PowerUpScript {
+  private const float TWEEN_TIME = 0.7f;
+
+  private static PlayerScalePowerUp? _scaleOwner = null;
+
+  public abstract float ScaleFactor { get; }
+
+  private Tween? _tweener = null;
+
+  public override void _Ready() {
+    base._Ready();
+    SetProcess(false);
+    _scaleOwner = this;
+    _tweenScaleTo(ScaleFactor);
+  }
+
+  public override void _ExitTree() {
+    base._ExitTree();
+    _tweener?.Kill();
+    _tweener = null;
+    if (!IsStillRelevant()) {
+      return;
+    }
+    _scaleOwner = null;
+    _restorePlayerScale();
+  }
+
+  public override bool IsStillRelevant() => ReferenceEquals(_scaleOwner, this);
+
+  private void _tweenScaleTo(float target) {
+    var player = Global.Instance().Player;
+    _tweener?.Kill();
+    _tweener = CreateTween();
+    _tweener.TweenProperty(
+        player,
+        Node2D.PropertyName.Scale.ToString(),
+        new Vector2(target, target),
+        TWEEN_TIME
+    ).SetTrans(Tween.TransitionType.Linear
+    ).SetEase(Tween.EaseType.InOut
+    ).From(player.Scale);
+  }
+
+  // Also reached with the level coming down around it, where the player is already gone.
+  private static void _restorePlayerScale() {
+    var player = Global.Instance()?.Player;
+    if (player is not null && GodotObject.IsInstanceValid(player)) {
+      player.Scale = Vector2.One;
+    }
+  }
+}

--- a/src/Wfc/Entities/World/BrickBreaker/Powerups/PlayerScalePowerUp/PlayerScalePowerUp.cs.uid
+++ b/src/Wfc/Entities/World/BrickBreaker/Powerups/PlayerScalePowerUp/PlayerScalePowerUp.cs.uid
@@ -1,0 +1,1 @@
+uid://by8u3r6rrtqhv

--- a/src/Wfc/Entities/World/BrickBreaker/Powerups/ScaleDownPowerUp/ScaleDownPowerUp.cs
+++ b/src/Wfc/Entities/World/BrickBreaker/Powerups/ScaleDownPowerUp/ScaleDownPowerUp.cs
@@ -1,45 +1,7 @@
 namespace Wfc.Entities.World.BrickBreaker.Powerups;
 
-using System;
-using Godot;
-using Wfc.Entities.World.Player;
-using Wfc.Utils;
-
-public partial class ScaleDownPowerUp : PowerUpScript {
-  private const float TWEEN_TIME = 0.7f;
+public partial class ScaleDownPowerUp : PlayerScalePowerUp {
   private const float SCALE_FACTOR = 0.7f;
 
-  private Tween? _tweener = null;
-
-  public override void _ExitTree() {
-    if (IsStillRelevant()) {
-      Player player = Global.Instance().Player;
-      player.Scale = new Vector2(1.0f, 1.0f);
-    }
-  }
-
-  private void InterpolateSize(Player player, float before, float after, float seconds) {
-
-    _tweener?.Kill();
-    _tweener = CreateTween();
-    _tweener.TweenProperty(
-        player,
-        Node2D.PropertyName.Scale.ToString(),
-        new Vector2(after, after),
-        seconds
-    ).SetTrans(Tween.TransitionType.Linear
-    ).SetEase(Tween.EaseType.InOut
-    ).From(new Vector2(before, before));
-  }
-
-  public override void _Ready() {
-    SetProcess(false);
-    Player player = Global.Instance().Player;
-    InterpolateSize(player, player.Scale.X, SCALE_FACTOR, TWEEN_TIME);
-  }
-
-  public override bool IsStillRelevant() {
-    Player player = Global.Instance().Player;
-    return Mathf.Abs(player.Scale.X - SCALE_FACTOR) < MathUtils.EPSILON;
-  }
+  public override float ScaleFactor => SCALE_FACTOR;
 }

--- a/src/Wfc/Entities/World/BrickBreaker/Powerups/ScaleUpPowerUp/ScaleUpPowerUp.cs
+++ b/src/Wfc/Entities/World/BrickBreaker/Powerups/ScaleUpPowerUp/ScaleUpPowerUp.cs
@@ -1,44 +1,7 @@
 namespace Wfc.Entities.World.BrickBreaker.Powerups;
 
-using System;
-using Godot;
-using Wfc.Entities.World.Player;
-using Wfc.Utils;
-
-public partial class ScaleUpPowerUp : PowerUpScript {
-  private const float TWEEN_TIME = 0.7f;
+public partial class ScaleUpPowerUp : PlayerScalePowerUp {
   private const float SCALE_FACTOR = 1.3f;
 
-  private Tween? _tweener = null;
-
-  public override void _ExitTree() {
-    if (IsStillRelevant()) {
-      Player player = Global.Instance().Player;
-      player.Scale = new Vector2(1.0f, 1.0f);
-    }
-  }
-
-  private void InterpolateSize(Player player, float before, float after, float seconds) {
-    _tweener?.Kill();
-    _tweener = CreateTween();
-    _tweener.TweenProperty(
-        player,
-        Node2D.PropertyName.Scale.ToString(),
-        new Vector2(after, after),
-        seconds
-    ).SetTrans(Tween.TransitionType.Linear
-    ).SetEase(Tween.EaseType.InOut
-    ).From(new Vector2(before, before));
-  }
-
-  public override void _Ready() {
-    SetProcess(false);
-    Player player = Global.Instance().Player;
-    InterpolateSize(player, player.Scale.X, SCALE_FACTOR, TWEEN_TIME);
-  }
-
-  public override bool IsStillRelevant() {
-    Player player = Global.Instance().Player;
-    return Mathf.Abs(player.Scale.X - SCALE_FACTOR) < MathUtils.EPSILON;
-  }
+  public override float ScaleFactor => SCALE_FACTOR;
 }

--- a/src/Wfc/Entities/World/Player/Player/Player.cs
+++ b/src/Wfc/Entities/World/Player/Player/Player.cs
@@ -193,6 +193,9 @@ public partial class Player : CharacterBody2D, IPersistent {
     AnimatedSpriteNode.Stop();
     GlobalPosition = new Vector2(_saveData.PositionX, _saveData.PositionY);
     Velocity = Vector2.Zero;
+    // The brick breaker's power-ups are the only thing that resizes the cube, and none of them
+    // outlives a respawn.
+    Scale = Vector2.One;
     Rotate(_saveData.Angle - Rotation);
     PlayerRotationAction.Reset(_saveData.Angle);
     CurrentDefaultCornerScaleFactor = _saveData.DefaultCornerScaleFactor;

--- a/src/Wfc/Entities/World/Player/State/PlayerSlipperingState/PlayerSlipperingState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerSlipperingState/PlayerSlipperingState.cs
@@ -104,6 +104,8 @@ public partial class PlayerSlipperingState : PlayerBaseState {
       return statesStore.GetState<PlayerStandingState>();
     }
 
+    // Scale.X is the cube's size and never a facing sign - `direction` is the only thing that
+    // decides which way it slides. A power-up that resizes the cube resizes how hard it pushes.
     if (_checkIfGroundIsNear(player, direction, RAY_LENGTH_FOR_SLIPPER)) {
       player.Velocity = new Vector2(
         player.Velocity.X + player.Scale.X * direction * PLAYER_SPEED_THRESHOLD_TO_STAND,

--- a/test/Instrumented/src/BrickBreaker/ScalePowerUpTests.cs
+++ b/test/Instrumented/src/BrickBreaker/ScalePowerUpTests.cs
@@ -1,0 +1,103 @@
+namespace Wfc.test.instrumented.BrickBreaker;
+
+using System.Threading.Tasks;
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Entities.World.BrickBreaker.Powerups;
+using Wfc.test.instrumented.Helpers.Fakes;
+using Wfc.Utils;
+
+// The two size power-ups share one value on the player and take a while to reach the size they
+// promise. Anything that takes one away before it gets there - another pickup, a death, leaving
+// the room - has to leave the cube at the size the rest of the game is built around, since nothing
+// downstream has any way of telling a power-up's size from a stranded one.
+public class ScalePowerUpTests(Node testScene) : TestClass(testScene) {
+  private const string PLAYER_SCENE = "res://src/Wfc/Entities/World/Player/Player/Player.tscn";
+  private const int SETTLE_FRAMES = 120;
+
+  private FakeDependenciesProvider _provider = default!;
+  private Wfc.Entities.World.Player.Player _player = default!;
+
+  [Setup]
+  public async Task Setup() {
+    _provider = new FakeDependenciesProvider();
+    TestScene.AddChild(_provider);
+    _player = GD.Load<PackedScene>(PLAYER_SCENE).Instantiate<Wfc.Entities.World.Player.Player>();
+    _provider.AddChild(_player);
+    await _idle();
+    _player.SetPhysicsProcess(false);
+  }
+
+  [Cleanup]
+  public void Cleanup() {
+    _player.QueueFree();
+    _provider.QueueFree();
+  }
+
+  [Test]
+  public async Task ASizeChangeTakenAwayPartWayThroughIsStillHandedBack() {
+    var powerUp = _pickUp<ScaleUpPowerUp>();
+    await _idle();
+
+    _player.Scale.X.ShouldBeGreaterThan(1.0f, "the cube should have started growing");
+    _player.Scale.X.ShouldBeLessThan(powerUp.ScaleFactor, "the test needs the cube caught mid-change");
+
+    powerUp.QueueFree();
+    await _idle();
+
+    _player.Scale.ShouldBe(Vector2.One);
+  }
+
+  [Test]
+  public async Task TheOppositeSizeChangeTakesTheCubeOverFromWhereverItIs() {
+    var grow = _pickUp<ScaleUpPowerUp>();
+    await _idle();
+
+    var shrink = _pickUp<ScaleDownPowerUp>();
+    // What the handler does with the power-up its replacement has just taken over from.
+    grow.QueueFree();
+    await _settled(shrink.ScaleFactor);
+
+    _player.Scale.X.ShouldBe(shrink.ScaleFactor, MathUtils.EPSILON, "the replacement owns the size now");
+
+    shrink.QueueFree();
+    await _idle();
+
+    _player.Scale.ShouldBe(Vector2.One);
+  }
+
+  [Test]
+  public async Task RespawningGivesTheCubeItsOwnSizeBack() {
+    var powerUp = _pickUp<ScaleDownPowerUp>();
+    await _settled(powerUp.ScaleFactor);
+
+    _player.Reset();
+
+    _player.Scale.ShouldBe(Vector2.One);
+
+    powerUp.QueueFree();
+    await _idle();
+  }
+
+  // Parented as the handler parents them, which is what starts the size change.
+  private T _pickUp<T>() where T : PlayerScalePowerUp, new() {
+    var powerUp = new T();
+    _provider.AddChild(powerUp);
+    return powerUp;
+  }
+
+  private async Task _settled(float scale) {
+    for (var frame = 0; frame < SETTLE_FRAMES; frame++) {
+      if (Mathf.Abs(_player.Scale.X - scale) < MathUtils.EPSILON) {
+        return;
+      }
+      await _idle();
+    }
+  }
+
+  private async Task _idle() {
+    var tree = TestScene.GetTree();
+    await tree.ToSignal(tree, SceneTree.SignalName.ProcessFrame);
+  }
+}

--- a/test/Instrumented/src/BrickBreaker/ScalePowerUpTests.cs.uid
+++ b/test/Instrumented/src/BrickBreaker/ScalePowerUpTests.cs.uid
@@ -1,0 +1,1 @@
+uid://rrjod4jnkv8d


### PR DESCRIPTION
The scale power-ups can strand player.Scale. IsStillRelevant() only matches the exact end-of-tween value (ScaleUpPowerUp.cs:40-43). A power-up removed mid-tween — by RemoveIrrelevantPowerups, by dying, or by picking up the opposite one — never restores Scale = 1, and Player.Reset() doesn't reset it either. The cube then plays the rest of the level at, say, 1.15, and PlayerSlipperingState compounds it by using player.Scale.X as a velocity multiplier (PlayerSlipperingState.cs:109, :118) where it reads like a leftover facing sign.
