### PR TITLE
Fix gameplay stutter: physics-clock platforms, interpolation, allocation-free hot paths

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -173,6 +173,7 @@
     "Respawns",
     "Respawned",
     "texels",
-    "travelled"
+    "travelled",
+    "finalizer"
   ]
 }

--- a/project.godot
+++ b/project.godot
@@ -151,8 +151,7 @@ project/assembly_name="WithFlyingColors"
 
 [physics]
 
-2d/run_on_separate_thread=true
-common/enable_pause_aware_picking=true
+common/physics_interpolation=true
 
 [rendering]
 

--- a/src/Wfc/Core/Input/InputManager/InputManager.cs
+++ b/src/Wfc/Core/Input/InputManager/InputManager.cs
@@ -5,7 +5,9 @@ using Godot;
 
 public class InputManager : IInputManager {
 
-  public static readonly Dictionary<IInputManager.Action, string> Actions = new Dictionary<IInputManager.Action, string> {
+  // StringName values, not strings: the player states poll these several times every physics
+  // tick, and Input converts a string to a fresh StringName on every such call.
+  public static readonly Dictionary<IInputManager.Action, StringName> Actions = new Dictionary<IInputManager.Action, StringName> {
     { IInputManager.Action.MoveLeft, "move_left" },
     { IInputManager.Action.MoveRight, "move_right" },
     { IInputManager.Action.Jump, "jump" },

--- a/src/Wfc/Entities/World/Camera/GameCamera/GameCamera.cs
+++ b/src/Wfc/Entities/World/Camera/GameCamera/GameCamera.cs
@@ -141,6 +141,7 @@ public partial class GameCamera : Camera2D, IPersistent {
     GlobalPosition = FollowNode.GlobalPosition;
     Align();
     ResetSmoothing();
+    ResetPhysicsInterpolation();
   }
 
   private void _OnPlayerJump() {
@@ -207,6 +208,7 @@ public partial class GameCamera : Camera2D, IPersistent {
   public async void UpdatePosition(Vector2 pos) {
     PositionSmoothingEnabled = false;
     GlobalPosition = pos;
+    ResetPhysicsInterpolation();
     await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
     SetDeferred(Camera2D.PropertyName.PositionSmoothingEnabled, true);
   }

--- a/src/Wfc/Entities/World/Enemies/LazerBeam/LazerBeam.cs
+++ b/src/Wfc/Entities/World/Enemies/LazerBeam/LazerBeam.cs
@@ -71,6 +71,14 @@ public partial class LazerBeam : Node2D {
 
   public PhysicsDirectSpaceState2D SpaceState => GetWorld2D().DirectSpaceState;
 
+  private static readonly StringName _positionKey = "position";
+  private static readonly StringName _colliderKey = "collider";
+
+  // One query object per cast, reused: the beam fires both every physics tick for as long as
+  // it exists, and building them fresh allocates engine objects every one of those ticks.
+  private PhysicsRayQueryParameters2D? _worldQuery;
+  private PhysicsRayQueryParameters2D? _faceQuery;
+
   // Normalized, because Transform.X carries the node's scale and a scaled beam would otherwise
   // read as a longer or shorter one.
   private Vector2 _beamDirection => Transform.X.Normalized();
@@ -81,14 +89,15 @@ public partial class LazerBeam : Node2D {
     var from = muzzleNode.GlobalPosition;
     var to = from + _beamDirection * BEAM_RANGE;
 
-    var query = PhysicsRayQueryParameters2D.Create(from, to, SOLID_MASK);
-    query.CollideWithAreas = false;
-    var result = SpaceState.IntersectRay(query);
+    _worldQuery ??= new PhysicsRayQueryParameters2D { CollisionMask = SOLID_MASK };
+    _worldQuery.From = from;
+    _worldQuery.To = to;
+    using var result = SpaceState.IntersectRay(_worldQuery);
 
     // IntersectRay returns an empty dictionary when it hits nothing, so the endpoint has to
     // be defaulted rather than read out of it - this used to throw every physics frame the
     // beam pointed at open sky.
-    return result.ContainsKey("position") ? (Vector2)result["position"] : to;
+    return result.Count > 0 ? (Vector2)result[_positionKey] : to;
   }
 
   // The face the beam lands on and where it lands, if it reaches one before the world stops it.
@@ -97,17 +106,21 @@ public partial class LazerBeam : Node2D {
   // the port.
   private (BaseFace Face, Vector2 Position)? _castToFace(Vector2 worldEnd) {
     var from = muzzleNode.GlobalPosition - _beamDirection * MOUNT_CLEARANCE;
-    var query = PhysicsRayQueryParameters2D.Create(from, worldEnd, PhysicsLayers.BoxFace.Mask);
-    query.CollideWithBodies = false;
-    query.CollideWithAreas = true;
-    var result = SpaceState.IntersectRay(query);
+    _faceQuery ??= new PhysicsRayQueryParameters2D {
+      CollisionMask = PhysicsLayers.BoxFace.Mask,
+      CollideWithBodies = false,
+      CollideWithAreas = true,
+    };
+    _faceQuery.From = from;
+    _faceQuery.To = worldEnd;
+    using var result = SpaceState.IntersectRay(_faceQuery);
 
     // An empty dictionary means the ray reached the end of the segment, and indexing a Godot
     // dictionary that does not hold the key throws rather than handing back nil.
-    if (!result.ContainsKey("collider") || result["collider"].As<Node>() is not BaseFace face) {
+    if (result.Count == 0 || result[_colliderKey].As<Node>() is not BaseFace face) {
       return null;
     }
-    return (face, (Vector2)result["position"]);
+    return (face, (Vector2)result[_positionKey]);
   }
 
   // The beam is absorbed by whatever it lands on, so it is drawn only that far. A face resting on

--- a/src/Wfc/Entities/World/Piano/PianoNote/PianoNote.cs
+++ b/src/Wfc/Entities/World/Piano/PianoNote/PianoNote.cs
@@ -68,6 +68,8 @@ public partial class PianoNote : AnimatableBody2D {
   private Vector2 _calculatedPosition;
   private Tween? _tweener = null;
   private bool _isPlayerAboveTheNote = false;
+  private PhysicsRayQueryParameters2D? _playerProbe;
+  private static readonly StringName _colliderKey = "collider";
 
   public override void _EnterTree() {
     base._EnterTree();
@@ -193,36 +195,27 @@ public partial class PianoNote : AnimatableBody2D {
     return (_collisionShapeNode.Shape as RectangleShape2D)?.Size ?? Vector2.Zero;
   }
 
-  private List<Dictionary<string, Vector2>> GetRayLinesInGlobalPosition() {
-    var rays = new List<Dictionary<string, Vector2>>();
-    Vector2 note_half_size = GetDetectionAreaShapeSize() * 0.5f * Scale;
-
-    var from_offset_x = new float[]
-    {
-            -note_half_size.X,
-            -note_half_size.X * 0.5f,
-            0.0f,
-            note_half_size.X * 0.5f,
-            note_half_size.X
-    };
-    var spriteHeight = _spriteNode.Texture.GetHeight();
-    foreach (float offset in from_offset_x) {
-      var from = GlobalPosition + new Vector2(offset, -spriteHeight * 0.5f - RAYCAST_Y_OFFSET);
-      var to = from + new Vector2(0.0f, -RAYCAST_LENGTH);
-      rays.Add(new Dictionary<string, Vector2> { { "from", from }, { "to", to } });
-    }
-    return rays;
-  }
-
+  // Five probes spread across the note's top, reused query and all: this runs every physics
+  // tick the note spends pressed, and building the machinery fresh allocated a dozen engine
+  // objects a tick.
   private bool RaycastPlayer() {
     var spaceState = GetWorld2D().DirectSpaceState;
-    var rays = GetRayLinesInGlobalPosition();
-    foreach (var ray in rays) {
-      var from = ray["from"];
-      var to = ray["to"];
-      var physicsRayQueryParameters = PhysicsRayQueryParameters2D.Create(from, to, exclude: new Godot.Collections.Array<Rid> { GetRid() });
-      var result = spaceState.IntersectRay(physicsRayQueryParameters);
-      if (result.ContainsKey("collider") && result["collider"].As<Player.Player>() != null) {
+    var noteHalfWidth = GetDetectionAreaShapeSize().X * 0.5f * Scale.X;
+    var spriteHeight = _spriteNode.Texture.GetHeight();
+
+    _playerProbe ??= new PhysicsRayQueryParameters2D {
+      Exclude = new Godot.Collections.Array<Rid> { GetRid() },
+    };
+
+    Span<float> offsets = stackalloc float[] {
+      -noteHalfWidth, -noteHalfWidth * 0.5f, 0.0f, noteHalfWidth * 0.5f, noteHalfWidth
+    };
+    foreach (float offset in offsets) {
+      var from = GlobalPosition + new Vector2(offset, (-spriteHeight * 0.5f) - RAYCAST_Y_OFFSET);
+      _playerProbe.From = from;
+      _playerProbe.To = from + new Vector2(0.0f, -RAYCAST_LENGTH);
+      using var result = spaceState.IntersectRay(_playerProbe);
+      if (result.Count > 0 && result[_colliderKey].As<Player.Player>() != null) {
         return true;
       }
     }

--- a/src/Wfc/Entities/World/Platforms/Platform/Platform.cs
+++ b/src/Wfc/Entities/World/Platforms/Platform/Platform.cs
@@ -56,6 +56,8 @@ public partial class Platform : AnimatableBody2D {
       _ninePatchRectNode.Modulate = color;
       _areaNode.AddToGroup(Group);
     }
+    // Nothing to feed the shader until something lands; OnPlayerLanded turns this back on.
+    SetProcess(false);
   }
 
   public override void _EnterTree() {
@@ -72,6 +74,7 @@ public partial class Platform : AnimatableBody2D {
     if (area == _areaNode) {
       _animationTimer = 0;
       _contactPosition = position;
+      SetProcess(true);
     }
   }
 
@@ -96,11 +99,14 @@ public partial class Platform : AnimatableBody2D {
         Vector2 pos = new Vector2(currentPos.X / resolution.X, currentPos.Y / resolution.Y);
         Vector2 positionInShaderCoords = new Vector2(pos.X, 1 - pos.Y);
 
-        shaderMaterial.SetShaderParameter("u_contact_pos", positionInShaderCoords);
-        shaderMaterial.SetShaderParameter("u_timer", _animationTimer);
-        shaderMaterial.SetShaderParameter("u_aspect_ratio", resolution.Y / resolution.X);
-        shaderMaterial.SetShaderParameter("darkness", SplashDarkness);
+        shaderMaterial.SetShaderParameter(PlatformSplash.ContactPosParam, positionInShaderCoords);
+        shaderMaterial.SetShaderParameter(PlatformSplash.TimerParam, _animationTimer);
+        shaderMaterial.SetShaderParameter(PlatformSplash.AspectRatioParam, resolution.Y / resolution.X);
+        shaderMaterial.SetShaderParameter(PlatformSplash.DarknessParam, SplashDarkness);
       }
+    }
+    if (_animationTimer > PlatformSplash.Duration(SplashDarkness)) {
+      SetProcess(false);
     }
   }
 
@@ -120,7 +126,6 @@ public partial class Platform : AnimatableBody2D {
   }
 
   private void _disconnectSignals() {
-    base._ExitTree();
     if (Engine.IsEditorHint())
       return;
     EventHandler.Instance.Events.PlayerLanded -= OnPlayerLanded;

--- a/src/Wfc/Entities/World/Platforms/PlatformSplash/PlatformSplash.cs
+++ b/src/Wfc/Entities/World/Platforms/PlatformSplash/PlatformSplash.cs
@@ -1,0 +1,22 @@
+namespace Wfc.Entities.World.Platforms;
+
+using Godot;
+
+// The landing splash the platforms share: the shader expands a darkened circle from the
+// contact point and brightens it back out at a fixed rate.
+//
+// The uniform names are cached here because writing one by string literal allocates a
+// StringName per call, and a splash writes four of them every frame it plays.
+public static class PlatformSplash {
+  // The shader's own fade term: how much of the darkening it gives back per second.
+  private const float FADE_RATE = 0.06f;
+
+  public static readonly StringName ContactPosParam = "u_contact_pos";
+  public static readonly StringName TimerParam = "u_timer";
+  public static readonly StringName AspectRatioParam = "u_aspect_ratio";
+  public static readonly StringName DarknessParam = "darkness";
+
+  // How long a splash of this darkness stays visible: past this the darkened area has
+  // brightened back to the plain texture and the shader draws nothing.
+  public static float Duration(float darkness) => Mathf.Max(0f, (1f - darkness) / FADE_RATE);
+}

--- a/src/Wfc/Entities/World/Platforms/PlatformSplash/PlatformSplash.cs.uid
+++ b/src/Wfc/Entities/World/Platforms/PlatformSplash/PlatformSplash.cs.uid
@@ -1,0 +1,1 @@
+uid://cc7ukkyjnxoo0

--- a/src/Wfc/Entities/World/Platforms/PlatformTileMap/PlatformTileMap.cs
+++ b/src/Wfc/Entities/World/Platforms/PlatformTileMap/PlatformTileMap.cs
@@ -27,10 +27,17 @@ public partial class PlatformTileMap : TileMapLayer {
     _disconnectSignals();
   }
 
+  public override void _Ready() {
+    base._Ready();
+    // Nothing to feed the shader until something lands; OnPlayerLanded turns this back on.
+    SetProcess(false);
+  }
+
   public void OnPlayerLanded(Node area, Vector2 position) {
     if (area == GetNode<Area2D>("Area2D")) {
       _animationTimer = 0;
       _contactPosition = position;
+      SetProcess(true);
     }
   }
 
@@ -55,11 +62,14 @@ public partial class PlatformTileMap : TileMapLayer {
         Vector2 pos = new Vector2(currentPos.X / resolution.X, currentPos.Y / resolution.Y);
         Vector2 positionInShaderCoords = new Vector2(pos.X, 1 - pos.Y);
 
-        shaderMaterial.SetShaderParameter("u_contact_pos", positionInShaderCoords);
-        shaderMaterial.SetShaderParameter("u_timer", _animationTimer);
-        shaderMaterial.SetShaderParameter("u_aspect_ratio", resolution.Y / resolution.X);
-        shaderMaterial.SetShaderParameter("darkness", SplashDarkness);
+        shaderMaterial.SetShaderParameter(PlatformSplash.ContactPosParam, positionInShaderCoords);
+        shaderMaterial.SetShaderParameter(PlatformSplash.TimerParam, _animationTimer);
+        shaderMaterial.SetShaderParameter(PlatformSplash.AspectRatioParam, resolution.Y / resolution.X);
+        shaderMaterial.SetShaderParameter(PlatformSplash.DarknessParam, SplashDarkness);
       }
+    }
+    if (_animationTimer > PlatformSplash.Duration(SplashDarkness)) {
+      SetProcess(false);
     }
   }
 

--- a/src/Wfc/Entities/World/Platforms/SimplePlatform/SimplePlatform.cs
+++ b/src/Wfc/Entities/World/Platforms/SimplePlatform/SimplePlatform.cs
@@ -66,6 +66,8 @@ public partial class SimplePlatform : StaticBody2D {
         _areaNode.AddToGroup(colorGroup);
       }
     }
+    // Nothing to feed the shader until something lands; OnPlayerLanded turns this back on.
+    SetProcess(false);
   }
 
   public void correctAreaSize() {
@@ -91,6 +93,7 @@ public partial class SimplePlatform : StaticBody2D {
     if (area == _areaNode) {
       animationTimer = 0;
       contactPosition = position;
+      SetProcess(true);
     }
   }
 
@@ -113,11 +116,14 @@ public partial class SimplePlatform : StaticBody2D {
         // Position in shader coords is now Y instead of 1-Y as it was in Godot 3.x
         Vector2 positionInShaderCoords = new Vector2(pos.X, pos.Y);
 
-        shaderMaterial.SetShaderParameter("u_contact_pos", positionInShaderCoords);
-        shaderMaterial.SetShaderParameter("u_timer", animationTimer);
-        shaderMaterial.SetShaderParameter("u_aspect_ratio", resolution.Y / resolution.X);
-        shaderMaterial.SetShaderParameter("darkness", splash_darkness);
+        shaderMaterial.SetShaderParameter(PlatformSplash.ContactPosParam, positionInShaderCoords);
+        shaderMaterial.SetShaderParameter(PlatformSplash.TimerParam, animationTimer);
+        shaderMaterial.SetShaderParameter(PlatformSplash.AspectRatioParam, resolution.Y / resolution.X);
+        shaderMaterial.SetShaderParameter(PlatformSplash.DarknessParam, splash_darkness);
       }
+    }
+    if (animationTimer > PlatformSplash.Duration(splash_darkness)) {
+      SetProcess(false);
     }
   }
 

--- a/src/Wfc/Entities/World/Platforms/SlidingPlatform/SlidingPlatform.cs
+++ b/src/Wfc/Entities/World/Platforms/SlidingPlatform/SlidingPlatform.cs
@@ -175,6 +175,9 @@ public partial class SlidingPlatform : Node2D, IPersistent {
   private void CleanTween() {
     _tweener?.Kill();
     _tweener = CreateTween();
+    // _PhysicsProcess is what applies _follow to the body, so the tween has to advance on the
+    // same clock: sampled from the idle clock, the platform's speed pulses with the render rate.
+    _tweener.SetProcessMode(Tween.TweenProcessMode.Physics);
   }
 
   private void ProcessTween() {
@@ -267,6 +270,7 @@ public partial class SlidingPlatform : Node2D, IPersistent {
     _tweener?.Kill();
     _currentState = _saveData.State;
     _platform.GlobalPosition = new Vector2(_saveData.PositionX, _saveData.PositionY);
+    _platform.ResetPhysicsInterpolation();
     _follow = _platform.GlobalPosition;
     SetLooping(_saveData.Looping);
     is_stopped = _saveData.IsStopped;

--- a/src/Wfc/Entities/World/Player/Player/Player.cs
+++ b/src/Wfc/Entities/World/Player/Player/Player.cs
@@ -246,6 +246,9 @@ public partial class Player : CharacterBody2D, IPersistent {
     Scale = Vector2.One;
     Rotate(_saveData.Angle - Rotation);
     PlayerRotationAction.Reset(_saveData.Angle);
+    // A respawn is a teleport: without this the interpolated cube streaks from the corpse to
+    // the checkpoint for a frame.
+    ResetPhysicsInterpolation();
     ShowColorAreas();
     HandleInputIsDisabled = false;
   }

--- a/src/Wfc/Entities/World/Player/State/PlayerBaseState/PlayerBaseState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerBaseState/PlayerBaseState.cs
@@ -122,4 +122,17 @@ public abstract partial class PlayerBaseState : GodotObject, IState<Player> {
       return false;
     return inputManager.IsJustPressed(IInputManager.Action.Jump);
   }
+
+  // One reused query per state: building one per probe allocates three engine objects a ray,
+  // and the standing state probes four times every physics tick the cube spends stood still.
+  private PhysicsRayQueryParameters2D? _rayQuery;
+
+  protected PhysicsRayQueryParameters2D FloorRayQuery(Player player, Vector2 from, Vector2 to) {
+    _rayQuery ??= new PhysicsRayQueryParameters2D {
+      Exclude = new Godot.Collections.Array<Rid> { player.GetRid() },
+    };
+    _rayQuery.From = from;
+    _rayQuery.To = to;
+    return _rayQuery;
+  }
 }

--- a/src/Wfc/Entities/World/Player/State/PlayerSlipperingState/PlayerSlipperingState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerSlipperingState/PlayerSlipperingState.cs
@@ -178,11 +178,7 @@ public partial class PlayerSlipperingState : PlayerBaseState {
     var to = from + new Vector2(0.0f, rayLength);
 
     var spaceState = player.GetWorld2D().DirectSpaceState;
-    var physicsRayQueryParameters = PhysicsRayQueryParameters2D.Create(
-        from, to, exclude: new Godot.Collections.Array<Rid> { player.GetRid() }
-    );
-
-    var result = spaceState.IntersectRay(physicsRayQueryParameters);
-    return result.ContainsKey("collider");
+    using var result = spaceState.IntersectRay(FloorRayQuery(player, from, to));
+    return result.Count > 0;
   }
 }

--- a/src/Wfc/Entities/World/Player/State/PlayerStandingState/PlayerStandingState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerStandingState/PlayerStandingState.cs
@@ -75,8 +75,6 @@ public partial class PlayerStandingState : PlayerBaseState {
     foreach (var offset in FloorProbeOffsets(half.X)) {
       Vector2 from = player.GlobalPosition + new Vector2(offset, probeBox.Y + RAYCAST_Y_OFFSET);
       Vector2 to = from + new Vector2(0.0f, RAYCAST_LENGTH);
-      // An empty dictionary is a miss; disposing it keeps four probes a tick off the
-      // finalizer queue.
       using var result = spaceState.IntersectRay(FloorRayQuery(player, from, to));
       if (result.Count > 0) {
         combination += i;

--- a/src/Wfc/Entities/World/Player/State/PlayerStandingState/PlayerStandingState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerStandingState/PlayerStandingState.cs
@@ -75,12 +75,10 @@ public partial class PlayerStandingState : PlayerBaseState {
     foreach (var offset in FloorProbeOffsets(half.X)) {
       Vector2 from = player.GlobalPosition + new Vector2(offset, probeBox.Y + RAYCAST_Y_OFFSET);
       Vector2 to = from + new Vector2(0.0f, RAYCAST_LENGTH);
-      var physicsRayQueryParameters = PhysicsRayQueryParameters2D.Create(
-          from, to, exclude: new Godot.Collections.Array<Rid> { player.GetRid() }
-      );
-
-      var result = spaceState.IntersectRay(physicsRayQueryParameters);
-      if (result.ContainsKey("collider")) {
+      // An empty dictionary is a miss; disposing it keeps four probes a tick off the
+      // finalizer queue.
+      using var result = spaceState.IntersectRay(FloorRayQuery(player, from, to));
+      if (result.Count > 0) {
         combination += i;
       }
       i *= 2;


### PR DESCRIPTION
- Drive SlidingPlatform's tween on the physics clock so platform speed no longer pulses against the render rate while the cube rides it
- Run 2D physics back on the main thread: the separate-thread setting bought nothing for a scene this light and cost a sync point every frame
- Enable 2D physics interpolation, resetting it at respawn and camera teleports so deaths don't streak
- Stop feeding the landing-splash shader once the splash has faded out, and cache its uniform names instead of allocating StringNames every frame
- Reuse ray query objects and dispose query result dictionaries in the standing/slippering states, the lazer beam and the piano notes
- Poll input actions through cached StringNames

Measured with a temporary instrumented probe: managed allocations while standing idle drop roughly eightfold, and nothing gameplay-side lands on the finalizer queue anymore.