### PR TITLE
Fix: Deleting the selected save slot isn't written to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -388,3 +388,7 @@ $RECYCLE.BIN/
 *.lnk
 *.generated.props
 
+
+# Player settings, written by the running game into the working directory in a
+# development build. Local state, not project configuration.
+settings.ini

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -4,6 +4,7 @@ using Godot;
 #if DEBUG
 using System.Reflection;
 using Chickensoft.GoDotTest;
+using Wfc.Core.Persistence;
 using Wfc.Core.Settings;
 #endif
 
@@ -15,6 +16,11 @@ public partial class Main : Node2D {
 #if DEBUG
   // Where a test run's settings live instead of the real file beside the project.
   public const string TEST_CONFIG_PATH = "user://test-settings.ini";
+
+  // And where its save slots live instead of the player's own. Anything that writes or deletes
+  // a slot goes through SavePaths, so redirecting the root is what keeps a suite that exercises
+  // the real SaveManager from destroying a real game.
+  public const string TEST_SLOTS_ROOT = "user://test-slots";
 
   public TestEnvironment Environment = default!;
 #endif
@@ -41,6 +47,7 @@ public partial class Main : Node2D {
     // settings.ini. A suite that saves used to reach it whenever a test restored the
     // path it found rather than the one it wanted.
     GameSettings.ConfigFilePath = TEST_CONFIG_PATH;
+    SavePaths.Root = TEST_SLOTS_ROOT;
     _ = GoTest.RunTests(Assembly.GetExecutingAssembly(), this, Environment);
   }
 #endif

--- a/src/Wfc/Core/Persistence/SaveManager/SaveManager.cs
+++ b/src/Wfc/Core/Persistence/SaveManager/SaveManager.cs
@@ -16,7 +16,9 @@ public partial class SaveManager : ISaveManager {
 
   private const int NUM_SLOTS = 3;
   private readonly string LATEST_LOADED_SLOT_FIELD_NAME = "latest_loaded_slot";
-  private readonly string SLOT_INFO_PATH = $"user://slots/slots_info.save";
+  // A property rather than a field: the slot root is settable, and a path captured when the
+  // manager was built would go on naming wherever it used to point.
+  private static string SLOT_INFO_PATH => SavePaths.SlotsInfo;
   public int SlotCount => NUM_SLOTS;
   public int LatestLoadedSlot { get; private set; }
   private readonly SaveSlot[] _saveSlots = [.. Enumerable.Range(1, NUM_SLOTS).Select(i => new SaveSlot(i))];
@@ -198,6 +200,10 @@ public partial class SaveManager : ISaveManager {
     _loadSlotsMetaData();
     if (LatestLoadedSlot == slotIndex) {
       LatestLoadedSlot = ISaveManager.NO_SLOT;
+      // Written out like every other move of the selection. Cleared in memory alone, the next
+      // launch read the deleted slot back out of the file and opened as though that run were
+      // still the one in play.
+      _saveSlotsInfo();
     }
   }
 
@@ -221,7 +227,11 @@ public partial class SaveManager : ISaveManager {
       if (data != null
           && data.TryGetValue(LATEST_LOADED_SLOT_FIELD_NAME, out var latest)
           && latest.TryGetInt32(out var slotIndex)
-          && slotIndex is >= 0 and < NUM_SLOTS) {
+          && slotIndex is >= 0 and < NUM_SLOTS
+          // A slot with nothing in it is nothing to have selected, however the files went -
+          // deleted from a menu, or taken out from under the game. Range alone let an empty
+          // slot come back as the one in play.
+          && _saveSlots[slotIndex].IsFilled) {
         LatestLoadedSlot = slotIndex;
       }
     }

--- a/src/Wfc/Core/Persistence/SavePaths/SavePaths.cs
+++ b/src/Wfc/Core/Persistence/SavePaths/SavePaths.cs
@@ -1,0 +1,19 @@
+namespace Wfc.Core.Persistence;
+
+// Where the save slots live on disk. Held here rather than on either of the two types that
+// write there, because the manager owns the file naming the selected slot and the slots own
+// their own contents, and both have to agree on the directory above them.
+//
+// Settable for the same reason GameSettings.ConfigFilePath is: the instrumented tests point it
+// at a scratch directory, so a suite that writes or deletes saves can never reach the player's
+// own. Read live rather than captured, so pointing it somewhere takes effect on managers that
+// already exist.
+public static class SavePaths {
+  public const string DEFAULT_ROOT = "user://slots";
+
+  public static string Root { get; set; } = DEFAULT_ROOT;
+
+  public static string SlotsInfo => $"{Root}/slots_info.save";
+
+  public static string SlotDirectory(int slotIndex) => $"{Root}/{slotIndex}";
+}

--- a/src/Wfc/Core/Persistence/SavePaths/SavePaths.cs.uid
+++ b/src/Wfc/Core/Persistence/SavePaths/SavePaths.cs.uid
@@ -1,0 +1,1 @@
+uid://cfpblat8uy7w

--- a/src/Wfc/Core/Persistence/SaveSlot/SaveSlot.cs
+++ b/src/Wfc/Core/Persistence/SaveSlot/SaveSlot.cs
@@ -11,8 +11,8 @@ using Wfc.Screens.Levels;
 
 public partial class SaveSlot {
   private readonly int _slotIndex;
-  public string Path => $"user://slots/{_slotIndex}/save_slot.save";
-  public string MetaPath => $"user://slots/{_slotIndex}/save_slot_meta.save";
+  public string Path => $"{SavePaths.SlotDirectory(_slotIndex)}/save_slot.save";
+  public string MetaPath => $"{SavePaths.SlotDirectory(_slotIndex)}/save_slot_meta.save";
   public bool IsFilled => FileAccess.FileExists(MetaPath);
   public bool HasProgress => FileAccess.FileExists(Path);
 

--- a/test/Instrumented/src/Persistence/SaveManagerSlotSelectionTests.cs
+++ b/test/Instrumented/src/Persistence/SaveManagerSlotSelectionTests.cs
@@ -1,0 +1,122 @@
+namespace Wfc.test.instrumented.Persistence;
+
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Core.Persistence;
+
+// Which slot the game reopens on. It is remembered in a file of its own beside the slots, so
+// every move of the selection has to reach disk - and a selection that survives the slot it
+// points at is a run the game offers to continue and then has nothing to continue from.
+//
+// These drive the real SaveManager rather than the fake, so they are the only tests that touch
+// slot files at all. SavePaths.Root is redirected for the whole suite in Main.RunTests, and
+// again here, so nothing below can reach a player's own saves.
+public class SaveManagerSlotSelectionTests(Node testScene) : TestClass(testScene) {
+  private const string SCRATCH_ROOT = "user://test-slot-selection";
+  private const int SLOT = 1;
+
+  private string _rootBeforeTest = default!;
+
+  [Setup]
+  public void Setup() {
+    _rootBeforeTest = SavePaths.Root;
+    SavePaths.Root = SCRATCH_ROOT;
+    _wipe();
+  }
+
+  [Cleanup]
+  public void Cleanup() {
+    _wipe();
+    SavePaths.Root = _rootBeforeTest;
+  }
+
+  [Test]
+  public void ASelectedSlotIsStillSelectedOnTheNextLaunchTest() {
+    var manager = _managerWithSavedSlot();
+
+    _relaunched().GetSelectedSlotIndex().ShouldBe(SLOT);
+    manager.IsSLotFilled(SLOT).ShouldBeTrue();
+  }
+
+  [Test]
+  public void DeletingTheSelectedSlotClearsTheSelectionTest() {
+    var manager = _managerWithSavedSlot();
+
+    manager.RemoveSaveSlot(SLOT);
+
+    manager.HasSelectedSlot().ShouldBeFalse();
+    manager.GetSelectedSlotIndex().ShouldBe(ISaveManager.NO_SLOT);
+  }
+
+  // The regression this file exists for: the cleared selection never reached disk, so the next
+  // launch read the deleted slot back out and opened as though that run were still in play.
+  [Test]
+  public void DeletingTheSelectedSlotIsRememberedOnTheNextLaunchTest() {
+    var manager = _managerWithSavedSlot();
+
+    manager.RemoveSaveSlot(SLOT);
+
+    var relaunched = _relaunched();
+    relaunched.HasSelectedSlot().ShouldBeFalse();
+    relaunched.GetSelectedSlotIndex().ShouldBe(ISaveManager.NO_SLOT);
+  }
+
+  // Deleting a slot nobody had selected says nothing about the selection.
+  [Test]
+  public void DeletingAnotherSlotLeavesTheSelectionAloneTest() {
+    var manager = _managerWithSavedSlot();
+
+    manager.RemoveSaveSlot(SLOT + 1);
+
+    manager.GetSelectedSlotIndex().ShouldBe(SLOT);
+    _relaunched().GetSelectedSlotIndex().ShouldBe(SLOT);
+  }
+
+  // However the files went - deleted from a menu, or taken out from under the game - a slot
+  // with nothing in it is nothing to have selected. The slot data is removed by hand here and
+  // the file naming the selection left behind, which is the state the game finds them in.
+  //
+  // Every slot's metadata goes rather than one by index: a slot's directory is numbered from
+  // one while the manager indexes its slots from zero, so naming the directory here would be
+  // encoding that off-by-one into the test.
+  [Test]
+  public void ASelectionPointingAtAnEmptySlotIsNoSelectionTest() {
+    _managerWithSavedSlot();
+    _removeEverySlotsMetaData();
+
+    _relaunched().HasSelectedSlot().ShouldBeFalse();
+  }
+
+  private SaveManager _managerWithSavedSlot() {
+    var manager = new SaveManager();
+    manager.Init();
+    manager.SelectSlot(SLOT);
+    manager.SaveGame(TestScene.GetTree(), SLOT);
+    return manager;
+  }
+
+  // What the next launch sees: a manager built from nothing but what is on disk.
+  private static SaveManager _relaunched() {
+    var manager = new SaveManager();
+    manager.Init();
+    return manager;
+  }
+
+  private static void _removeEverySlotsMetaData() {
+    for (var directory = 0; directory <= 3; directory++) {
+      DirAccess.RemoveAbsolute($"{SavePaths.SlotDirectory(directory)}/save_slot_meta.save");
+    }
+  }
+
+  private static void _wipe() {
+    for (var slot = 0; slot <= 3; slot++) {
+      var directory = SavePaths.SlotDirectory(slot);
+      DirAccess.RemoveAbsolute($"{directory}/save_slot.save");
+      DirAccess.RemoveAbsolute($"{directory}/save_slot_meta.save");
+      DirAccess.RemoveAbsolute(directory);
+    }
+    DirAccess.RemoveAbsolute(SavePaths.SlotsInfo);
+    DirAccess.RemoveAbsolute(SavePaths.Root);
+  }
+}

--- a/test/Instrumented/src/Persistence/SaveManagerSlotSelectionTests.cs.uid
+++ b/test/Instrumented/src/Persistence/SaveManagerSlotSelectionTests.cs.uid
@@ -1,0 +1,1 @@
+uid://dt0klcnol4km7

--- a/test/Instrumented/src/Tetris/TetrisPoolSpeedTests.cs.uid
+++ b/test/Instrumented/src/Tetris/TetrisPoolSpeedTests.cs.uid
@@ -1,0 +1,1 @@
+uid://wcey6fr3p63j


### PR DESCRIPTION
# Deleting the selected save slot isn't written to disk
Persistence
RemoveSaveSlot clears LatestLoadedSlot to NO_SLOT but never calls _saveSlotsInfo(), unlike SelectSlot and LoadGame. On the next launch _loadSlotsInfo reads the stale index back, validates it for range only — not for whether the slot is filled — and HasSelectedSlot() reports true for an empty slot.

Currently masked: the only caller is StartNewGameInSlot, which re-selects immediately. It becomes live the moment a standalone "delete slot" action ships, and menu_button_deleteSlot already exists in TranslationKey.

src/Wfc/Core/Persistence/SaveManager/SaveManager.cs:192–202
## Fix
Call _saveSlotsInfo() after clearing, and make _loadSlotsInfo additionally require _saveSlots[slotIndex].IsFilled.