### PR TITLE
Fix: MusicTrackManager.RemoveTrack orphans its stream player

### DIFF
--- a/src/Wfc/Core/Audio/Music/MusicTrackManager/MusicTrackManager.cs
+++ b/src/Wfc/Core/Audio/Music/MusicTrackManager/MusicTrackManager.cs
@@ -45,7 +45,10 @@ public partial class MusicTrackManager : Node2D, IMusicTrackManager, IPersistent
   private const int EFF_INDEX = 0;
   private const int NOTCH_EFF_INDEX = 1;
 
-  private const int BUS_INDEX = 1;
+  // Looked up by name rather than pinned to a position in the layout. The bus order is a
+  // resource the project is free to rearrange, and an effect added to the wrong bus says
+  // nothing about it - the music simply stops answering the pause filter and the pitch.
+  private static int BusIndex => AudioServer.GetBusIndex(BUS_NAME);
 
   private State _currentState = State.STOPPED;
 
@@ -65,25 +68,25 @@ public partial class MusicTrackManager : Node2D, IMusicTrackManager, IPersistent
     var shift = new AudioEffectPitchShift {
       PitchScale = 1.0f
     };
-    AudioServer.AddBusEffect(BUS_INDEX, shift, EFF_INDEX);
+    AudioServer.AddBusEffect(BusIndex, shift, EFF_INDEX);
   }
 
   private static void AddNotchEffect() {
     var notch = new AudioEffectNotchFilter {
       Resonance = 0.05f
     };
-    AudioServer.AddBusEffect(BUS_INDEX, notch, NOTCH_EFF_INDEX);
+    AudioServer.AddBusEffect(BusIndex, notch, NOTCH_EFF_INDEX);
   }
 
   public void SetPauseMenuEffect(bool isOn) {
-    AudioServer.SetBusEffectEnabled(BUS_INDEX, NOTCH_EFF_INDEX, isOn);
+    AudioServer.SetBusEffectEnabled(BusIndex, NOTCH_EFF_INDEX, isOn);
   }
 
   public void SetPitchScale(float _pitch_scale) {
     if (_currentTrack == null)
       return;
 
-    var shift = (AudioEffectPitchShift)AudioServer.GetBusEffect(BUS_INDEX, EFF_INDEX);
+    var shift = (AudioEffectPitchShift)AudioServer.GetBusEffect(BusIndex, EFF_INDEX);
     shift.PitchScale = 1.0f / _pitch_scale;
     _currentTrack.Stream.PitchScale = _pitch_scale;
     this._pitchScale = _pitch_scale;
@@ -123,11 +126,12 @@ public partial class MusicTrackManager : Node2D, IMusicTrackManager, IPersistent
       return;
     }
 
-    var music = value;
-    if (music != null) {
-      RemoveChild(music.Stream);
-      _musicPool.Remove(name);
-    }
+    // Freed, not merely detached. Dropping the pool entry is the last reference this side
+    // holds, so a player left unfreed keeps itself and the stream it loaded for the rest of
+    // the process with nothing able to reach it.
+    RemoveChild(value.Stream);
+    value.Stream.QueueFree();
+    _musicPool.Remove(name);
   }
 
   public void PlayTrack(string name) {

--- a/test/Instrumented/src/Audio/MusicTrackManagerTests.cs
+++ b/test/Instrumented/src/Audio/MusicTrackManagerTests.cs
@@ -1,0 +1,89 @@
+namespace Wfc.test.instrumented.Audio;
+
+using System.Threading.Tasks;
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Core.Audio;
+using Wfc.Utils;
+
+// The music player owns two things the rest of the game cannot see: an AudioStreamPlayer per
+// track it has loaded, and the effects it hangs on the music bus. Both outlive anything that
+// merely drops a reference, so both are worth pinning down.
+public class MusicTrackManagerTests(Node testScene) : TestClass(testScene) {
+  private const string TRACK = "fight";
+  private const string BUS = "music";
+
+  private MusicTrackManager _manager = default!;
+  private int _effectsBeforeTest;
+
+  // Adding a bus effect is process-wide and nothing takes it off again, so the manager built
+  // here leaves two behind on the bus the real one is already using. They are counted going in
+  // and taken off again on the way out, or every suite after this one runs against a music bus
+  // with a growing stack of duplicates on it.
+  [Setup]
+  public async Task Setup() {
+    _effectsBeforeTest = AudioServer.GetBusEffectCount(AudioServer.GetBusIndex(BUS));
+    _manager = SceneHelpers.InstantiateNode<MusicTrackManager>();
+    TestScene.AddChild(_manager);
+    await _idle();
+  }
+
+  [Cleanup]
+  public void Cleanup() {
+    _manager.QueueFree();
+    var busIndex = AudioServer.GetBusIndex(BUS);
+    while (AudioServer.GetBusEffectCount(busIndex) > _effectsBeforeTest) {
+      AudioServer.RemoveBusEffect(busIndex, 0);
+    }
+  }
+
+  // The effects are placed by name, so rearranging the bus layout cannot silently send them to
+  // whichever bus happens to sit at that position.
+  [Test]
+  public void ItHangsItsEffectsOnTheMusicBusTest() {
+    var busIndex = AudioServer.GetBusIndex(BUS);
+
+    AudioServer.GetBusEffectCount(busIndex).ShouldBe(_effectsBeforeTest + 2);
+    AudioServer.GetBusName(busIndex).ShouldBe(BUS);
+  }
+
+  [Test]
+  public async Task LoadingATrackGivesItAPlayerOnTheMusicBusTest() {
+    _manager.LoadTrack(TRACK);
+    await _idle();
+
+    var player = _playerOf(_manager).ShouldNotBeNull();
+    player.Bus.ToString().ShouldBe(BUS);
+  }
+
+  // The regression this file exists for: the player was detached and the pool entry dropped,
+  // which left nothing able to reach it and nothing to free it.
+  [Test]
+  public async Task RemovingATrackFreesItsPlayerTest() {
+    _manager.LoadTrack(TRACK);
+    await _idle();
+    var player = _playerOf(_manager).ShouldNotBeNull();
+
+    _manager.RemoveTrack(TRACK);
+    await _idle();
+
+    GodotObject.IsInstanceValid(player).ShouldBeFalse("the stream player should have been freed");
+    _playerOf(_manager).ShouldBeNull();
+  }
+
+  private static AudioStreamPlayer? _playerOf(Node manager) {
+    foreach (var child in manager.GetChildren()) {
+      if (child is AudioStreamPlayer player && !player.IsQueuedForDeletion()) {
+        return player;
+      }
+    }
+    return null;
+  }
+
+  private async Task _idle() {
+    var tree = TestScene.GetTree();
+    await tree.ToSignal(tree, SceneTree.SignalName.ProcessFrame);
+    await tree.ToSignal(tree, SceneTree.SignalName.ProcessFrame);
+  }
+}


### PR DESCRIPTION
# MusicTrackManager.RemoveTrack orphans its stream player
Leak
It calls `RemoveChild(music.Stream)` and drops the dictionary entry, but never frees the node. Detached from the tree with no C# reference left, the `AudioStreamPlayer` and its loaded stream stay alive for the process. It is the only `RemoveChild` in the repo not followed by a `QueueFree` — the other eight all pair correctly.

`src/Wfc/Core/Audio/Music/MusicTrackManager/MusicTrackManager.cs:120–131`

## Fix
Add `music.Stream.QueueFree()`. While in the file, replace the hardcoded `BUS_INDEX = 1` with `AudioServer.GetBusIndex(BUS_NAME)` — the pitch and notch effects are currently pinned to a bus by position, and reordering `default_bus_layout.tres` would silently apply them to the wrong bus.