### PR TITLE
Fix test suite leaked object

### DIFF
--- a/src/Wfc/Core/Types/ColorGroup/ColorGroup.cs
+++ b/src/Wfc/Core/Types/ColorGroup/ColorGroup.cs
@@ -4,7 +4,7 @@ using Godot;
 using Wfc.Skin;
 using Wfc.Utils.Colors;
 
-public partial class ColorGroup : GodotObject {
+public class ColorGroup {
   public string Value { get; }
   public SkinColor SkinColor { get; }
 

--- a/src/Wfc/Entities/World/Explosion/Explosion/ExplosionInfo.cs
+++ b/src/Wfc/Entities/World/Explosion/Explosion/ExplosionInfo.cs
@@ -2,7 +2,7 @@ namespace Wfc.Entities.World.Explosion;
 
 using Godot;
 
-public partial class ExplosionInfo : GodotObject {
+public class ExplosionInfo {
   public Node2D BlocksContainer { get; set; }
   public bool CanDetonate { get; set; }
   public Vector2 CollisionExtents { get; set; }

--- a/src/Wfc/Entities/World/Player/Rotation/PlayerRotationAction.cs
+++ b/src/Wfc/Entities/World/Player/Rotation/PlayerRotationAction.cs
@@ -4,7 +4,7 @@ using System;
 using Godot;
 using Wfc.Utils;
 
-public partial class PlayerRotationAction : GodotObject {
+public class PlayerRotationAction {
   private const float DEFAULT_ROTATION_DURATION = 0.1f;
   private const float FULL_TURN = Mathf.Pi * 2.0f;
 

--- a/src/Wfc/Entities/World/Player/State/PlayerBaseState/PlayerBaseState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerBaseState/PlayerBaseState.cs
@@ -5,7 +5,7 @@ using Wfc.Core.Input;
 using Wfc.State;
 using Wfc.Utils;
 
-public abstract partial class PlayerBaseState : GodotObject, IState<Player> {
+public abstract class PlayerBaseState : IState<Player> {
   const float GRAVITY = 9.8f * Constants.WORLD_TO_SCREEN;
   const float FALL_FACTOR = 2.5f;
   const float RUN_DAMPING = 0.25f;

--- a/src/Wfc/Entities/World/Player/State/PlayerExplosionState/PlayerExplosionState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerExplosionState/PlayerExplosionState.cs
@@ -20,18 +20,10 @@ public partial class PlayerExplosionState : PlayerDyingBaseState {
     player.Velocity = Vector2.Zero;
     lightMask = player.LightOccluder.OccluderLightMask;
     // create the explosion
-    CallDeferred(nameof(CreateExplosion), player);
+    Callable.From(() => CreateExplosion(player)).CallDeferred();
     EventHandler.Instance.EmitPlayerExplode();
     player.LightOccluder.OccluderLightMask = 0;
     player.AnimatedSpriteNode.Play("die");
-  }
-
-  private void OnAnimationFinished(Player player) {
-    player.AnimatedSpriteNode.Disconnect(
-      AnimatedSprite2D.SignalName.AnimationFinished,
-      new Callable(this, nameof(OnAnimationFinished))
-    );
-    EventHandler.Instance.EmitPlayerDied();
   }
 
   protected override void _Exit(Player player) {
@@ -39,13 +31,16 @@ public partial class PlayerExplosionState : PlayerDyingBaseState {
     player.LightOccluder.OccluderLightMask = lightMask;
   }
 
-  private void CreateExplosion(Player player) {
+  private static void CreateExplosion(Player player) {
     var explosion = SceneHelpers.InstantiateNode<Explosion>();
-    explosion.Connect(nameof(Explosion.ObjectDetonated), new Callable(this, nameof(OnObjectDetonated)), flags: (uint)ConnectFlags.OneShot);
+    explosion.Connect(
+      nameof(Explosion.ObjectDetonated),
+      Callable.From<Node>(OnObjectDetonated),
+      flags: (uint)GodotObject.ConnectFlags.OneShot);
     explosion.Connect(Node.SignalName.Ready, Callable.From(() => {
       explosion.Setup(player);
       explosion.FireExplosion();
-    }), (uint)ConnectFlags.OneShot);
+    }), (uint)GodotObject.ConnectFlags.OneShot);
     player.AddChild(explosion);
     explosion.Owner = player;
   }

--- a/src/Wfc/Entities/World/Player/State/PlayerSquashedState/PlayerSquashedState.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerSquashedState/PlayerSquashedState.cs
@@ -41,7 +41,7 @@ public partial class PlayerSquashedState : PlayerDyingBaseState {
       From = player.GlobalTransform,
       Motion = pin * reach,
     };
-    if (death.Source is PhysicsBody2D crusher && IsInstanceValid(crusher)) {
+    if (death.Source is PhysicsBody2D crusher && GodotObject.IsInstanceValid(crusher)) {
       probe.ExcludeBodies = new Godot.Collections.Array<Rid> { crusher.GetRid() };
     }
     var result = new PhysicsTestMotionResult2D();

--- a/src/Wfc/Entities/World/Player/State/PlayerStatesStore/PlayerStatesStore.cs
+++ b/src/Wfc/Entities/World/Player/State/PlayerStatesStore/PlayerStatesStore.cs
@@ -7,7 +7,7 @@ using Wfc.Core.Input;
 using Wfc.Screens.Levels;
 using Wfc.State;
 
-public partial class PlayerStatesStore : GodotObject, IPlayerStatesStore {
+public class PlayerStatesStore : IPlayerStatesStore {
 
   private readonly Dictionary<Type, IState<Player>> _states;
 

--- a/src/Wfc/Utils/CountdownTimer/CountdownTimer.cs
+++ b/src/Wfc/Utils/CountdownTimer/CountdownTimer.cs
@@ -3,7 +3,7 @@ namespace Wfc.Utils;
 using Godot;
 
 // Use built in timer instead. I was new to godot didn't know it existed :p
-public partial class CountdownTimer : GodotObject {
+public class CountdownTimer {
   private float _duration;
   private float _timer;
 


### PR DESCRIPTION
The suite exits leaking 3,541 objects
Investigate
Measured, and it was production code. A trivial suite leaks nothing, so there is no engine baseline: everything reported is ours. With --verbose every leaked instance came back named Object — the native base class, which is what a C# type deriving straight from GodotObject reports.

Six helper types were : GodotObject while using no Godot feature whatsoever — no signal, no Variant, no deferred call: PlayerStatesStore and the eleven states it builds, PlayerBaseState, PlayerRotationAction, CountdownTimer, ColorGroup, ExplosionInfo. C# does not own the native side of a non-RefCounted GodotObject, so none of them was ever freed: about nineteen objects per player, which is per level load, plus two per Menubox and one per explosion.

The reason this survived is that the orphan-node monitor cannot see it. That counter, the ORPHANS row in the performance overlay and PrintOrphanNodes all count Nodes; these are not Nodes. Only the exit dump reports them.

Fixed by making all six plain C# classes · two states reworked to lose the inherited base
Measured before and after
SceneOrchesterTests 352 → 0 · PlayerRespawnTests 132 → 8 · MenuScreenTests 56 → 0 · OrphanNodeTests 54 → 0. The residue is four Node2D+Timer pairs built by a test fixture, not by the game.