### PR TITLE
Refactor Game Pause

### DIFF
--- a/src/Wfc/Base/DependenciesProvider/DependenciesProvider.cs
+++ b/src/Wfc/Base/DependenciesProvider/DependenciesProvider.cs
@@ -27,16 +27,19 @@ public partial class DependenciesProvider :
   IProvide<ISfxManager>,
   IProvide<IMusicTrackManager>,
   IProvide<IInputManager>,
-  IProvide<IModalStack> {
+  IProvide<IModalStack>,
+  IProvide<IPauseOwnership> {
   public override void _Notification(int what) => this.Notify(what);
 
   private readonly Lazy<IMenuManager> _menuManager;
   private readonly Lazy<IInputManager> _inputManager;
   private readonly Lazy<IModalStack> _modalStack;
+  private readonly Lazy<IPauseOwnership> _pauseOwnership;
   private readonly ILogger _logger = new GDLogger();
   private readonly SaveManager _saveManager = new SaveManager();
   IMenuManager IProvide<IMenuManager>.Value() => _menuManager.Value;
   IModalStack IProvide<IModalStack>.Value() => _modalStack.Value;
+  IPauseOwnership IProvide<IPauseOwnership>.Value() => _pauseOwnership.Value;
   ISaveManager IProvide<ISaveManager>.Value() => _saveManager;
   ILocalizationService IProvide<ILocalizationService>.Value() => new LocalizationService();
   ILogger IProvide<ILogger>.Value() => _logger;
@@ -49,7 +52,8 @@ public partial class DependenciesProvider :
     _menuManager = new Lazy<IMenuManager>(() => new MenuManager(this));
     _inputManager = new Lazy<IInputManager>(() => new InputManager());
     // Lazy so GetTree() is only reached once this node is in the tree.
-    _modalStack = new Lazy<IModalStack>(() => new ModalStack(GetTree()));
+    _pauseOwnership = new Lazy<IPauseOwnership>(() => new PauseOwnership(GetTree()));
+    _modalStack = new Lazy<IModalStack>(() => new ModalStack(_pauseOwnership.Value));
   }
 
   public void OnReady() {

--- a/src/Wfc/Core/Ui/IPauseOwnership/IPauseOwnership.cs
+++ b/src/Wfc/Core/Ui/IPauseOwnership/IPauseOwnership.cs
@@ -1,0 +1,27 @@
+namespace Wfc.Core.Ui;
+
+using Godot;
+
+// Who is holding the game still.
+//
+// The tree's pause flag is a single boolean, and three unrelated things need the game held
+// at once: the pause menu, an overlay that has taken the screen, and the orchestrator while
+// it swaps a level behind the cover. Written directly, whichever touched it last won - so
+// the orchestrator had to ask the pause menu whether it was paused before daring to let go,
+// and the title card had to swallow the pause key so that nothing could take the flag while
+// a swap was covering.
+//
+// Here each of them claims and releases in its own name, and the game runs again only once
+// the last claim is gone. Nothing else writes SceneTree.Paused.
+public interface IPauseOwnership {
+  // True while anything is holding the game.
+  bool IsHeld { get; }
+
+  bool IsHeldBy(object owner);
+
+  // Claiming twice in the same name is the same as claiming once: the pause menu re-pauses
+  // itself whenever the window loses focus, whether or not it already had.
+  void Claim(object owner);
+
+  void Release(object owner);
+}

--- a/src/Wfc/Core/Ui/IPauseOwnership/IPauseOwnership.cs.uid
+++ b/src/Wfc/Core/Ui/IPauseOwnership/IPauseOwnership.cs.uid
@@ -1,0 +1,1 @@
+uid://cq5mr66cfcgtt

--- a/src/Wfc/Core/Ui/ModalStack/ModalStack.cs
+++ b/src/Wfc/Core/Ui/ModalStack/ModalStack.cs
@@ -4,16 +4,11 @@ using System.Collections.Generic;
 using Godot;
 
 public class ModalStack : IModalStack {
-  private readonly SceneTree _tree;
+  private readonly IPauseOwnership _pause;
   private readonly List<Node> _owners = [];
 
-  // What the pause flag was before the first overlay went up. The pause menu is
-  // already paused underneath its own overlays, so the stack restores rather than
-  // clears.
-  private bool _wasPausedBeforeFirstPush;
-
-  public ModalStack(SceneTree tree) {
-    _tree = tree;
+  public ModalStack(IPauseOwnership pause) {
+    _pause = pause;
   }
 
   public bool IsAnyOpen => _owners.Count > 0;
@@ -24,11 +19,10 @@ public class ModalStack : IModalStack {
     if (_owners.Contains(owner)) {
       return;
     }
-    if (_owners.Count == 0) {
-      _wasPausedBeforeFirstPush = _tree.Paused;
-      _tree.Paused = true;
-    }
     _owners.Add(owner);
+    // One claim for the stack rather than one per overlay: an overlay opened over another
+    // is still the same single reason the game is being held.
+    _pause.Claim(this);
   }
 
   public void Pop(Node owner) {
@@ -36,7 +30,9 @@ public class ModalStack : IModalStack {
       return;
     }
     if (_owners.Count == 0) {
-      _tree.Paused = _wasPausedBeforeFirstPush;
+      // Nothing is restored here. Whatever else was holding the game - the pause menu the
+      // overlay was opened on top of - is still holding it in its own name.
+      _pause.Release(this);
     }
   }
 }

--- a/src/Wfc/Core/Ui/PauseOwnership/PauseOwnership.cs
+++ b/src/Wfc/Core/Ui/PauseOwnership/PauseOwnership.cs
@@ -1,0 +1,46 @@
+namespace Wfc.Core.Ui;
+
+using System.Collections.Generic;
+using Godot;
+
+public class PauseOwnership : IPauseOwnership {
+  private readonly SceneTree _tree;
+  private readonly List<object> _owners = [];
+
+  public PauseOwnership(SceneTree tree) {
+    _tree = tree;
+  }
+
+  public bool IsHeld {
+    get {
+      _forgetFreedOwners();
+      return _owners.Count > 0;
+    }
+  }
+
+  public bool IsHeldBy(object owner) => _owners.Contains(owner);
+
+  public void Claim(object owner) {
+    if (!_owners.Contains(owner)) {
+      _owners.Add(owner);
+    }
+    _apply();
+  }
+
+  public void Release(object owner) {
+    _owners.Remove(owner);
+    _apply();
+  }
+
+  // A claim held by a node that has since been freed - a level swapped out from under an
+  // overlay that was still up - has nobody left to release it, and would hold the game for
+  // the rest of the run. The owners that hold claims release them as they leave the tree;
+  // this is the backstop for the ones that cannot.
+  private void _forgetFreedOwners() =>
+    _owners.RemoveAll(owner => owner is GodotObject godotOwner && !GodotObject.IsInstanceValid(godotOwner));
+
+  private void _apply() {
+    _forgetFreedOwners();
+    _tree.Paused = _owners.Count > 0;
+  }
+}

--- a/src/Wfc/Core/Ui/PauseOwnership/PauseOwnership.cs.uid
+++ b/src/Wfc/Core/Ui/PauseOwnership/PauseOwnership.cs.uid
@@ -1,0 +1,1 @@
+uid://ceioby7ynlkjc

--- a/src/Wfc/Screens/PauseMenu/PauseMenu/PauseMenu.cs
+++ b/src/Wfc/Screens/PauseMenu/PauseMenu/PauseMenu.cs
@@ -71,8 +71,21 @@ public partial class PauseMenu : CanvasLayer {
   public IInputManager InputManager => this.DependOn<IInputManager>();
   [Dependency]
   public IModalStack ModalStack => this.DependOn<IModalStack>();
+  [Dependency]
+  public IPauseOwnership PauseOwnership => this.DependOn<IPauseOwnership>();
 
   public void OnResolved() { }
+
+  // The level this menu belongs to is freed while it is still paused whenever the player
+  // restarts or walks out from the pause menu, and a claim nobody is left to release would
+  // hold the game still for the rest of the run.
+  public override void _ExitTree() {
+    base._ExitTree();
+    if (_isPaused) {
+      _isPaused = false;
+      PauseOwnership.Release(this);
+    }
+  }
 
   public override void _Ready() {
     this.WireNodes();
@@ -125,7 +138,7 @@ public partial class PauseMenu : CanvasLayer {
     _pauseMenu._Hide();
     _inputHintBar.Exit();
     _isPaused = false;
-    GetTree().Paused = false;
+    PauseOwnership.Release(this);
     EventHandler.Instance.EmitPauseMenuExit();
   }
 
@@ -136,7 +149,7 @@ public partial class PauseMenu : CanvasLayer {
     _pauseMenu._Show();
     _inputHintBar.Enter();
     _isPaused = true;
-    GetTree().Paused = true;
+    PauseOwnership.Claim(this);
     EventHandler.Instance.EmitPauseMenuEnter();
   }
 

--- a/src/Wfc/Screens/SceneOrchester/SceneOrchester.cs
+++ b/src/Wfc/Screens/SceneOrchester/SceneOrchester.cs
@@ -8,6 +8,7 @@ using Godot;
 using Wfc.Core.Audio;
 using Wfc.Core.Event;
 using Wfc.Core.Persistence;
+using Wfc.Core.Ui;
 using Wfc.Entities.Ui;
 using Wfc.Entities.World.Checkpoints;
 using Wfc.Entities.World.Door;
@@ -41,6 +42,9 @@ public partial class SceneOrchester : Node2D {
 
   [Dependency]
   public IMusicTrackManager MusicTrackManager => this.DependOn<IMusicTrackManager>();
+
+  [Dependency]
+  public IPauseOwnership PauseOwnership => this.DependOn<IPauseOwnership>();
 
   // The id the level's Cutscene node matches start and end requests on. Unique to
   // the intro so it cannot collide with a cutscene the level itself is running.
@@ -94,6 +98,9 @@ public partial class SceneOrchester : Node2D {
     base._ExitTree();
     DisconnectSignals();
     MusicTrackManager.Stop();
+    // A swap that was still covering when the screen was left would otherwise hold the game
+    // for the rest of the run, with the only thing that could let go of it gone.
+    PauseOwnership.Release(this);
   }
 
   public override void _Ready() {
@@ -288,7 +295,7 @@ public partial class SceneOrchester : Node2D {
     _pendingClearedLevelId = _currentLevelId;
     _pendingClearedGems = _collectedGemGroups();
     // Freeze play under the cover; the swap happens once it is opaque.
-    GetTree().Paused = true;
+    PauseOwnership.Claim(this);
     _titleCardNode.CoverForSwap();
   }
 
@@ -302,7 +309,7 @@ public partial class SceneOrchester : Node2D {
     _pendingClearedLevelId = null;
     _pendingClearedGems = [];
     _pendingRestart = false;
-    GetTree().Paused = true;
+    PauseOwnership.Claim(this);
     _titleCardNode.CoverForSwap();
   }
 
@@ -317,7 +324,7 @@ public partial class SceneOrchester : Node2D {
     _pendingClearedLevelId = null;
     _pendingClearedGems = [];
     _pendingRestart = true;
-    GetTree().Paused = true;
+    PauseOwnership.Claim(this);
     _titleCardNode.CoverForSwap();
   }
 
@@ -362,13 +369,11 @@ public partial class SceneOrchester : Node2D {
       SaveManager.RecordProgress(GetTree(), nextLevelId, 0);
     }
 
-    // Play resumes under the lifting cover, but inside the intro cutscene: the
-    // player is walked in while the title fades over the scene. If the window lost
-    // focus during the cover, the pause menu legitimately owns the pause now and
-    // keeps it.
-    if (_currentLevel?.PauseMenuNode.IsPaused != true) {
-      GetTree().Paused = false;
-    }
+    // Play resumes under the lifting cover, but inside the intro cutscene: the player is
+    // walked in while the title fades over the scene. Only this claim is let go: if the
+    // window lost focus during the cover, the pause menu is holding the game in its own
+    // name and goes on holding it.
+    PauseOwnership.Release(this);
     _beginLevelIntro();
   }
 

--- a/test/Instrumented/src/Async/AwaitLifetimeTests.cs.uid
+++ b/test/Instrumented/src/Async/AwaitLifetimeTests.cs.uid
@@ -1,0 +1,1 @@
+uid://de7ygc6iw8hgh

--- a/test/Instrumented/src/Audio/MusicTrackManagerTests.cs.uid
+++ b/test/Instrumented/src/Audio/MusicTrackManagerTests.cs.uid
@@ -1,0 +1,1 @@
+uid://crm3gk1kvjop3

--- a/test/Instrumented/src/Helpers/Fakes/FakeDependenciesProvider.cs
+++ b/test/Instrumented/src/Helpers/Fakes/FakeDependenciesProvider.cs
@@ -36,7 +36,8 @@ public partial class FakeDependenciesProvider :
   IProvide<ISfxManager>,
   IProvide<IMusicTrackManager>,
   IProvide<IInputManager>,
-  IProvide<IModalStack> {
+  IProvide<IModalStack>,
+  IProvide<IPauseOwnership> {
   public override void _Notification(int what) => this.Notify(what);
 
   public FakeInputManager Input { get; } = new();
@@ -46,6 +47,7 @@ public partial class FakeDependenciesProvider :
 
   private readonly Lazy<IMenuManager> _menuManager;
   private readonly Lazy<IModalStack> _modalStack;
+  private readonly Lazy<IPauseOwnership> _pauseOwnership;
   private readonly ILogger _logger = new GDLogger();
 
   IEventHandler IProvide<IEventHandler>.Value() => EventHandler.Instance;
@@ -57,6 +59,7 @@ public partial class FakeDependenciesProvider :
   IMusicTrackManager IProvide<IMusicTrackManager>.Value() => Wfc.Autoload.AutoloadManager.Instance.MusicTrackManager;
   IInputManager IProvide<IInputManager>.Value() => Input;
   IModalStack IProvide<IModalStack>.Value() => _modalStack.Value;
+  IPauseOwnership IProvide<IPauseOwnership>.Value() => _pauseOwnership.Value;
 
   public FakeDependenciesProvider() : base() {
     // Anything a test drives into saving (closing a settings view does) writes through
@@ -65,7 +68,8 @@ public partial class FakeDependenciesProvider :
     // two cannot drift apart.
     GameSettings.ConfigFilePath = WithFlyingColors.Main.TEST_CONFIG_PATH;
     _menuManager = new Lazy<IMenuManager>(() => new MenuManager(this));
-    _modalStack = new Lazy<IModalStack>(() => new ModalStack(GetTree()));
+    _pauseOwnership = new Lazy<IPauseOwnership>(() => new PauseOwnership(GetTree()));
+    _modalStack = new Lazy<IModalStack>(() => new ModalStack(_pauseOwnership.Value));
   }
 
   public void OnReady() => this.Provide();

--- a/test/src/Wfc/Core/Ui/ModalStack/ModalStackTests.cs
+++ b/test/src/Wfc/Core/Ui/ModalStack/ModalStackTests.cs
@@ -8,6 +8,7 @@ using Wfc.Core.Ui;
 
 public class ModalStackTests(Node testScene) : TestClass(testScene) {
   private SceneTree _tree = default!;
+  private PauseOwnership _pause = default!;
   private bool _pausedBeforeTest;
   private readonly List<Node> _owners = [];
 
@@ -15,6 +16,7 @@ public class ModalStackTests(Node testScene) : TestClass(testScene) {
   public void Setup() {
     _tree = TestScene.GetTree();
     _pausedBeforeTest = _tree.Paused;
+    _pause = new PauseOwnership(_tree);
   }
 
   [Cleanup]
@@ -35,7 +37,7 @@ public class ModalStackTests(Node testScene) : TestClass(testScene) {
 
   [Test]
   public void EmptyStack_IsNotOpenAndBlocksNobody() {
-    var stack = new ModalStack(_tree);
+    var stack = new ModalStack(_pause);
 
     stack.IsAnyOpen.ShouldBeFalse();
     stack.IsBlockedFor(NewOwner()).ShouldBeFalse();
@@ -44,7 +46,7 @@ public class ModalStackTests(Node testScene) : TestClass(testScene) {
   [Test]
   public void Push_OpensTheStackAndPausesTheTree() {
     _tree.Paused = false;
-    var stack = new ModalStack(_tree);
+    var stack = new ModalStack(_pause);
 
     stack.Push(NewOwner());
 
@@ -55,7 +57,7 @@ public class ModalStackTests(Node testScene) : TestClass(testScene) {
   [Test]
   public void PopOfLastOwner_ClosesTheStackAndUnpausesTheTree() {
     _tree.Paused = false;
-    var stack = new ModalStack(_tree);
+    var stack = new ModalStack(_pause);
     var owner = NewOwner();
 
     stack.Push(owner);
@@ -65,24 +67,30 @@ public class ModalStackTests(Node testScene) : TestClass(testScene) {
     _tree.Paused.ShouldBeFalse();
   }
 
-  // The pause menu is already paused underneath its own overlays, so the stack has to
-  // put the flag back rather than simply clear it.
+  // The pause menu is already holding the game underneath its own overlays. The stack no
+  // longer snapshots the flag to put it back: it lets go only of its own claim, and the
+  // menu's claim goes on holding the game by itself.
   [Test]
-  public void PopOfLastOwner_RestoresAPauseThatPredatedTheStack() {
-    _tree.Paused = true;
-    var stack = new ModalStack(_tree);
+  public void PopOfLastOwner_LeavesAPauseSomebodyElseIsHolding() {
+    _tree.Paused = false;
+    var somebodyElse = new object();
+    _pause.Claim(somebodyElse);
+    var stack = new ModalStack(_pause);
     var owner = NewOwner();
 
     stack.Push(owner);
     stack.Pop(owner);
 
     _tree.Paused.ShouldBeTrue();
+
+    _pause.Release(somebodyElse);
+    _tree.Paused.ShouldBeFalse();
   }
 
   [Test]
   public void NestedOwners_KeepTheTreePausedUntilTheLastPop() {
     _tree.Paused = false;
-    var stack = new ModalStack(_tree);
+    var stack = new ModalStack(_pause);
     var first = NewOwner();
     var second = NewOwner();
 
@@ -101,7 +109,7 @@ public class ModalStackTests(Node testScene) : TestClass(testScene) {
 
   [Test]
   public void IsBlockedFor_LetsOnlyTheTopmostOwnerThrough() {
-    var stack = new ModalStack(_tree);
+    var stack = new ModalStack(_pause);
     var below = NewOwner();
     var top = NewOwner();
 
@@ -116,7 +124,7 @@ public class ModalStackTests(Node testScene) : TestClass(testScene) {
   [Test]
   public void RepeatedPush_DoesNotNeedAMatchingExtraPop() {
     _tree.Paused = false;
-    var stack = new ModalStack(_tree);
+    var stack = new ModalStack(_pause);
     var owner = NewOwner();
 
     stack.Push(owner);
@@ -131,7 +139,7 @@ public class ModalStackTests(Node testScene) : TestClass(testScene) {
   [Test]
   public void PopOfAnOwnerThatNeverPushed_LeavesTheStackAlone() {
     _tree.Paused = false;
-    var stack = new ModalStack(_tree);
+    var stack = new ModalStack(_pause);
     var owner = NewOwner();
 
     stack.Push(owner);

--- a/test/src/Wfc/Core/Ui/PauseOwnership/PauseOwnershipTests.cs
+++ b/test/src/Wfc/Core/Ui/PauseOwnership/PauseOwnershipTests.cs
@@ -1,0 +1,121 @@
+namespace Wfc.Core.Ui.Test;
+
+using System.Collections.Generic;
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Core.Ui;
+
+// The game is held still by three unrelated things - the pause menu, an overlay holding the
+// screen, and the orchestrator swapping a level behind the cover - and before this each of
+// them wrote the tree's one pause flag directly, so the last to touch it won. What matters
+// here is that letting go of one claim never lets go of another's.
+public class PauseOwnershipTests(Node testScene) : TestClass(testScene) {
+  private SceneTree _tree = default!;
+  private bool _pausedBeforeTest;
+  private readonly List<Node> _nodes = [];
+
+  [Setup]
+  public void Setup() {
+    _tree = TestScene.GetTree();
+    _pausedBeforeTest = _tree.Paused;
+    _tree.Paused = false;
+  }
+
+  [Cleanup]
+  public void Cleanup() {
+    _tree.Paused = _pausedBeforeTest;
+    foreach (var node in _nodes) {
+      if (GodotObject.IsInstanceValid(node)) {
+        node.Free();
+      }
+    }
+    _nodes.Clear();
+  }
+
+  [Test]
+  public void NothingHeldMeansTheGameRunsTest() {
+    var pause = new PauseOwnership(_tree);
+
+    pause.IsHeld.ShouldBeFalse();
+    _tree.Paused.ShouldBeFalse();
+  }
+
+  [Test]
+  public void AClaimHoldsTheGameAndReleasingLetsItRunTest() {
+    var pause = new PauseOwnership(_tree);
+    var owner = new object();
+
+    pause.Claim(owner);
+    _tree.Paused.ShouldBeTrue();
+    pause.IsHeldBy(owner).ShouldBeTrue();
+
+    pause.Release(owner);
+    _tree.Paused.ShouldBeFalse();
+    pause.IsHeldBy(owner).ShouldBeFalse();
+  }
+
+  // The whole point of the thing. This is the F10 hazard: the orchestrator finishing a level
+  // swap used to write the flag false outright, which would have let go of an overlay's hold
+  // as well as its own.
+  [Test]
+  public void ReleasingOneClaimLeavesAnotherHoldingTest() {
+    var pause = new PauseOwnership(_tree);
+    var orchestrator = new object();
+    var overlay = new object();
+
+    pause.Claim(overlay);
+    pause.Claim(orchestrator);
+    pause.Release(orchestrator);
+
+    _tree.Paused.ShouldBeTrue("the overlay is still holding the game");
+
+    pause.Release(overlay);
+    _tree.Paused.ShouldBeFalse();
+  }
+
+  // The pause menu re-pauses itself every time the window loses focus, whether or not it had
+  // already, and the orchestrator claims once per swap however many it runs.
+  [Test]
+  public void ClaimingTwiceNeedsOnlyOneReleaseTest() {
+    var pause = new PauseOwnership(_tree);
+    var owner = new object();
+
+    pause.Claim(owner);
+    pause.Claim(owner);
+    pause.Release(owner);
+
+    _tree.Paused.ShouldBeFalse();
+  }
+
+  // Teardown paths let go without knowing whether they ever took hold.
+  [Test]
+  public void ReleasingSomethingThatNeverClaimedChangesNothingTest() {
+    var pause = new PauseOwnership(_tree);
+    var owner = new object();
+    pause.Claim(owner);
+
+    pause.Release(new object());
+
+    _tree.Paused.ShouldBeTrue();
+  }
+
+  // A level swapped out from under an overlay takes the overlay with it, and a claim held by
+  // something that no longer exists has nobody left to release it.
+  [Test]
+  public void AClaimHeldByAFreedNodeStopsCountingTest() {
+    var pause = new PauseOwnership(_tree);
+    var doomed = new Node();
+    _nodes.Add(doomed);
+    var survivor = new object();
+
+    pause.Claim(doomed);
+    pause.Claim(survivor);
+    doomed.Free();
+
+    pause.Release(survivor);
+
+    pause.IsHeld.ShouldBeFalse("a freed owner cannot go on holding the game");
+    _tree.Paused.ShouldBeFalse();
+  }
+}

--- a/test/src/Wfc/Core/Ui/PauseOwnership/PauseOwnershipTests.cs.uid
+++ b/test/src/Wfc/Core/Ui/PauseOwnership/PauseOwnershipTests.cs.uid
@@ -1,0 +1,1 @@
+uid://wvfw64a53omh


### PR DESCRIPTION
Three independent owners write GetTree().Paused
Design
Three unrelated things wrote the tree's one pause flag, so whichever touched it last won. SceneOrchester._onTitleCardCovered asked PauseMenu.IsPaused before letting go but never consulted ModalStack.

Unreachable today, and worth saying exactly why, because the reason is not in any of the code that depends on it: while a modal holds the screen the tree is paused, and every modal opener — Door, HubStatsBoard — is inherit process mode, so none of them can act to start a swap. During a swap the same freeze stops a new modal being opened. A process_mode = Always on one opener would have made it reachable, and the cost would have been worse than a desynced flag: the hub is freed mid-swap with its overlay still registered, leaving IsAnyOpen true for the rest of the run and the pause menu dead. The title card swallowing the pause key during a cover was a third piece of the same scaffolding.

Fixed with a PauseOwnership service. Each of the three claims and releases in its own name and the game runs again only when the last claim is gone, so letting go of one can no longer let go of another's. SceneTree.Paused now has exactly one writer in the whole codebase. The orchestrator's peek at PauseMenu.IsPaused is gone, and a claim held by a node that gets freed is dropped rather than holding the game for ever.

New: PauseOwnership · rewired: SceneOrchester, PauseMenu, ModalStack, DependenciesProvider
Verified
PauseOwnershipTests 6/6 and ModalStackTests 8/8, including the hazard itself: releasing the orchestrator's claim while an overlay holds one leaves the game held. One asserted contract changed on purpose — the stack no longer snapshots the flag to restore it, because the holder underneath now keeps its own claim.