### PR TITLE
Fix ScenePath

### DIFF
--- a/src/Wfc/Entities/Ui/Menubox/Menubox/Menubox.cs
+++ b/src/Wfc/Entities/Ui/Menubox/Menubox/Menubox.cs
@@ -12,7 +12,6 @@ using Wfc.Utils;
 using Wfc.Utils.Attributes;
 using EventHandler = Core.Event.EventHandler;
 
-[ScenePath]
 [Meta(typeof(IAutoNode))]
 public partial class Menubox : Control {
   #region Dependencies

--- a/src/Wfc/Entities/Ui/SettingsUI/UIkeyBinding/KeyBindingButton/KeyBindingButton.cs
+++ b/src/Wfc/Entities/Ui/SettingsUI/UIkeyBinding/KeyBindingButton/KeyBindingButton.cs
@@ -14,7 +14,6 @@ using Wfc.Utils;
 using Wfc.Utils.Attributes;
 using EventHandler = Wfc.Core.Event.EventHandler;
 
-[ScenePath]
 [Meta(typeof(IAutoNode))]
 public partial class KeyBindingButton : Button, IEditableControl, IDarkBackgroundAware {
 

--- a/src/Wfc/Entities/Ui/SettingsUI/UIkeyBinding/KeyBindingController/KeyBindingController.cs
+++ b/src/Wfc/Entities/Ui/SettingsUI/UIkeyBinding/KeyBindingController/KeyBindingController.cs
@@ -15,7 +15,6 @@ using Wfc.Utils.Attributes;
 using EventHandler = Wfc.Core.Event.EventHandler;
 
 
-[ScenePath]
 [Meta(typeof(IAutoNode))]
 public partial class KeyBindingController : PanelContainer {
 

--- a/src/Wfc/Utils/Attributes/LevelPathAttribute/LevelPathAttribute.cs
+++ b/src/Wfc/Utils/Attributes/LevelPathAttribute/LevelPathAttribute.cs
@@ -76,24 +76,12 @@ public class LevelPathAttribute : Attribute {
     }
   }
 
-  // Extracts the directory path after "WithFlyingColors" from the file path
-  private static string GetSceneDirFromCallerFilePath(string callerFilePath) {
-    if (string.IsNullOrEmpty(callerFilePath)) {
-      return string.Empty;
-    }
-
-    // Find the part after the last "WithFlyingColors": a checkout can sit inside a
-    // directory of the same name, which is exactly what GitHub Actions does
-    // (/home/runner/work/WithFlyingColors/WithFlyingColors/src/...). Splitting on the
-    // first occurrence there leaves the repo name glued to the front of the path and
-    // every level resolves to a res:// that does not exist.
-    var index = callerFilePath.LastIndexOf("WithFlyingColors", StringComparison.OrdinalIgnoreCase);
-    if (index == -1) {
-      return string.Empty;
-    }
-
-    var afterProject = callerFilePath.Substring(index + "WithFlyingColors".Length);
-    var dir = Path.GetDirectoryName(afterProject.Replace("\\", "/").TrimStart('/'));
-    return dir ?? string.Empty;
-  }
+  // The directory the calling file sits in, relative to the project root.
+  //
+  // This used to be found by splitting on the repository's own name, which broke once
+  // already on CI - it checks out into /home/runner/work/WithFlyingColors/WithFlyingColors,
+  // one directory of that name inside another - and broke outright for a clone into a
+  // directory called anything else. ProjectPath anchors on src/ instead.
+  private static string GetSceneDirFromCallerFilePath(string callerFilePath) =>
+    Path.GetDirectoryName(ProjectPath.RelativeToProjectRoot(callerFilePath)) ?? string.Empty;
 }

--- a/src/Wfc/Utils/Attributes/ProjectPath/ProjectPath.cs
+++ b/src/Wfc/Utils/Attributes/ProjectPath/ProjectPath.cs
@@ -1,0 +1,36 @@
+namespace Wfc.Utils.Attributes;
+
+using System;
+
+// Turns the compile-time path of a source file into the path Godot knows it by.
+//
+// Anchored on the project's own src directory, not on the name of the folder the repository
+// is checked out into. That name is nobody's to rely on: a clone into a directory called
+// anything else left every scene resolving to an absolute path on the machine that compiled
+// it, with nothing to say so until a scene failed to load. CI already checks out into
+// /home/runner/work/WithFlyingColors/WithFlyingColors, one directory of that name inside
+// another, which is the shape that broke the level paths once already.
+//
+// The constraint this trades for: a type carrying one of these attributes lives under src/.
+// Every one of them does, and a scene under test/ would resolve against the wrong src.
+public static class ProjectPath {
+  private const string SOURCE_ROOT = "/src/";
+
+  // Where the file sits relative to the project root - "src/Wfc/...cs" - or empty when it is
+  // not under src/ at all, which the caller reports rather than guessing at.
+  public static string RelativeToProjectRoot(string callerFilePath) {
+    if (string.IsNullOrEmpty(callerFilePath)) {
+      return string.Empty;
+    }
+    // Compiled on Windows, run anywhere: CallerFilePath keeps the separators of the machine
+    // that built it, and res:// only ever speaks in forward slashes.
+    var normalized = callerFilePath.Replace('\\', '/');
+    var index = normalized.LastIndexOf(SOURCE_ROOT, StringComparison.Ordinal);
+    return index < 0 ? string.Empty : normalized[(index + 1)..];
+  }
+
+  public static string ResPathOf(string callerFilePath) {
+    var relative = RelativeToProjectRoot(callerFilePath);
+    return relative.Length == 0 ? string.Empty : $"res://{relative}";
+  }
+}

--- a/src/Wfc/Utils/Attributes/ProjectPath/ProjectPath.cs.uid
+++ b/src/Wfc/Utils/Attributes/ProjectPath/ProjectPath.cs.uid
@@ -1,0 +1,1 @@
+uid://hc3jhj03a0va

--- a/src/Wfc/Utils/Attributes/ScenePathAttribute/ScenePathAttribute.cs
+++ b/src/Wfc/Utils/Attributes/ScenePathAttribute/ScenePathAttribute.cs
@@ -1,17 +1,25 @@
 namespace Wfc.Utils.Attributes;
 
 using System;
-using System.Linq;
 
 [AttributeUsage(AttributeTargets.Class)]
 public class ScenePathAttribute : Attribute {
+  private const string SOURCE_EXTENSION = ".cs";
+  private const string SCENE_EXTENSION = ".tscn";
+
   public string Path { get; }
 
+  // The scene beside the file this is written in. A res:// path given outright is taken as
+  // it stands; anything else is the compile-time path of that file, which ProjectPath reads
+  // without depending on what the checkout directory is called.
   public ScenePathAttribute([System.Runtime.CompilerServices.CallerFilePath] string path = "") {
-    if (!path.Contains("res://")) {
-      // Ensure that the game directory name is "WithFlyingColors"
-      path = "res://" + path.Split("WithFlyingColors").Last().Replace(".cs", ".tscn");
+    if (path.Contains("res://")) {
+      Path = path;
+      return;
     }
-    Path = path;
+    var resPath = ProjectPath.ResPathOf(path);
+    Path = resPath.EndsWith(SOURCE_EXTENSION, StringComparison.Ordinal)
+      ? resPath[..^SOURCE_EXTENSION.Length] + SCENE_EXTENSION
+      : resPath;
   }
 }

--- a/test/src/Wfc/Utils/Attributes/LevelPathAttributeTests.cs
+++ b/test/src/Wfc/Utils/Attributes/LevelPathAttributeTests.cs
@@ -63,7 +63,7 @@ public class LevelPathAttributeTests(Node testScene) : TestClass(testScene) {
 
   // This used to assert the fallback it produced when the checkout was not called
   // WithFlyingColors - "res://Level1.tscn", a level that does not exist - which is the bug
-  // rather than the behaviour. Nothing about the directory the repository sits in is the
+  // rather than the behavior. Nothing about the directory the repository sits in is the
   // project's to depend on.
   [Test]
   public void CallerFilePath_InACheckoutOfAnyName_StillResolves() {

--- a/test/src/Wfc/Utils/Attributes/LevelPathAttributeTests.cs
+++ b/test/src/Wfc/Utils/Attributes/LevelPathAttributeTests.cs
@@ -12,7 +12,10 @@ using Shouldly;
 using Wfc.Entities.World.Player;
 
 public class LevelPathAttributeTests(Node testScene) : TestClass(testScene) {
-  private const string FakeCallerFilePath = @"C:\Projects\WithFlyingColors\scenes\levels\LevelId.cs";
+  // The real LevelId.cs sits here. The paths below are only ever the compile-time location
+  // of that file on whichever machine built it.
+  private const string LEVEL_LIST_DIR = "src/Wfc/Screens/Levels/LevelList";
+  private const string FakeCallerFilePath = @"C:\Projects\WithFlyingColors\src\Wfc\Screens\Levels\LevelList\LevelId.cs";
 
   private Fixture _fixture = default!;
 
@@ -39,15 +42,13 @@ public class LevelPathAttributeTests(Node testScene) : TestClass(testScene) {
   [Test]
   public void RelativeFile_IsCombinedWithCallerDir() {
     var attr = new LevelPathAttribute("tutorialX", FakeCallerFilePath);
-    // Should resolve to res://scenes/levels/tutorialX.tscn
-    attr.ResolvePath("Tutorial").ShouldBe("res://scenes/levels/tutorialX.tscn");
+    attr.ResolvePath("Tutorial").ShouldBe($"res://{LEVEL_LIST_DIR}/tutorialX.tscn");
   }
 
   [Test]
   public void EmptyPath_UsesEnumNameAndCallerDir() {
     var attr = new LevelPathAttribute("", FakeCallerFilePath);
-    // Should resolve to res://scenes/levels/Level1.tscn
-    attr.ResolvePath("Level1").ShouldBe("res://scenes/levels/Level1.tscn");
+    attr.ResolvePath("Level1").ShouldBe($"res://{LEVEL_LIST_DIR}/Level1.tscn");
   }
 
   // GitHub Actions checks the repository out into a directory of the same name, so the
@@ -60,10 +61,13 @@ public class LevelPathAttributeTests(Node testScene) : TestClass(testScene) {
     attr.ResolvePath("Level1").ShouldBe("res://src/Wfc/Screens/Levels/LevelList/Level1.tscn");
   }
 
+  // This used to assert the fallback it produced when the checkout was not called
+  // WithFlyingColors - "res://Level1.tscn", a level that does not exist - which is the bug
+  // rather than the behaviour. Nothing about the directory the repository sits in is the
+  // project's to depend on.
   [Test]
-  public void CallerFilePath_WithoutProjectName_ReturnsScenes() {
-    var attr = new LevelPathAttribute("", @"C:\OtherProject\scenes\levels\LevelId.cs");
-    // Should fallback to res://Level1.tscn
-    attr.ResolvePath("Level1").ShouldBe("res://Level1.tscn");
+  public void CallerFilePath_InACheckoutOfAnyName_StillResolves() {
+    var attr = new LevelPathAttribute("", @"C:\OtherProject\src\Wfc\Screens\Levels\LevelList\LevelId.cs");
+    attr.ResolvePath("Level1").ShouldBe($"res://{LEVEL_LIST_DIR}/Level1.tscn");
   }
 }

--- a/test/src/Wfc/Utils/Attributes/ScenePathAttributeTests.cs
+++ b/test/src/Wfc/Utils/Attributes/ScenePathAttributeTests.cs
@@ -1,0 +1,74 @@
+namespace Wfc.Utils.Attributes.Test;
+
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Utils;
+using Wfc.Utils.Attributes;
+
+// Where a scene-backed type finds its scene. The attribute is handed the compile-time path of
+// the file it is written in, and has to turn that into a res:// path - which means deciding
+// where the project root is inside somebody's absolute path. It used to decide by looking for
+// the repository's own name, so the game only worked out of a directory called
+// WithFlyingColors.
+public class ScenePathAttributeTests(Node testScene) : TestClass(testScene) {
+  [Test]
+  public void ItNamesTheSceneBesideTheSourceFileTest() {
+    var attribute = new ScenePathAttribute("/home/dev/WithFlyingColors/src/Wfc/Entities/Ui/Thing/Thing.cs");
+
+    attribute.Path.ShouldBe("res://src/Wfc/Entities/Ui/Thing/Thing.tscn");
+  }
+
+  // The regression this file exists for: nothing about the checkout directory's name is the
+  // project's to depend on. This used to yield "res:///home/dev/MyGame/src/...", an absolute
+  // path on the build machine that resolves to nothing anywhere else.
+  [Test]
+  public void ACheckoutDirectoryOfAnyNameStillResolvesTest() {
+    var attribute = new ScenePathAttribute("/home/dev/MyGame/src/Wfc/Entities/Ui/Thing/Thing.cs");
+
+    attribute.Path.ShouldBe("res://src/Wfc/Entities/Ui/Thing/Thing.tscn");
+  }
+
+  // What CI actually does: one directory of the repository's name inside another.
+  [Test]
+  public void ANestedCheckoutOfTheSameNameResolvesTest() {
+    var attribute = new ScenePathAttribute(
+      "/home/runner/work/WithFlyingColors/WithFlyingColors/src/Wfc/Entities/Ui/Thing/Thing.cs");
+
+    attribute.Path.ShouldBe("res://src/Wfc/Entities/Ui/Thing/Thing.tscn");
+  }
+
+  // res:// only ever speaks in forward slashes, whatever the machine that compiled it used.
+  [Test]
+  public void AWindowsPathResolvesTest() {
+    var attribute = new ScenePathAttribute(@"D:\build\Whatever\src\Wfc\Entities\Ui\Thing\Thing.cs");
+
+    attribute.Path.ShouldBe("res://src/Wfc/Entities/Ui/Thing/Thing.tscn");
+  }
+
+  [Test]
+  public void APathGivenOutrightIsTakenAsItStandsTest() {
+    var attribute = new ScenePathAttribute("res://src/Wfc/Somewhere/Else.tscn");
+
+    attribute.Path.ShouldBe("res://src/Wfc/Somewhere/Else.tscn");
+  }
+
+  // Every scene-backed type in the game, resolved against the scenes actually on disk. This is
+  // what would have caught the original bug on any machine, without renaming anything.
+  [Test]
+  public void EverySceneBackedTypeFindsItsSceneTest() {
+    var missing = new System.Collections.Generic.List<string>();
+    foreach (var type in typeof(SceneHelpers).Assembly.GetTypes()) {
+      var attribute = System.Reflection.CustomAttributeExtensions
+        .GetCustomAttribute<ScenePathAttribute>(type);
+      if (attribute is null) {
+        continue;
+      }
+      if (!ResourceLoader.Exists(attribute.Path)) {
+        missing.Add($"{type.Name} -> '{attribute.Path}'");
+      }
+    }
+
+    missing.ShouldBeEmpty();
+  }
+}

--- a/test/src/Wfc/Utils/Attributes/ScenePathAttributeTests.cs.uid
+++ b/test/src/Wfc/Utils/Attributes/ScenePathAttributeTests.cs.uid
@@ -1,0 +1,1 @@
+uid://b40tdrnb02wsc


### PR DESCRIPTION
[ScenePath] depends on the checkout folder being named "WithFlyingColors"
Fragility
The attribute derives every scene path by splitting CallerFilePath on the literal string "WithFlyingColors" and taking the last segment. Clone the repo into a directory with any other name and Split returns a single element, so Last() yields the entire absolute path and every res:// lookup in the game fails at once — at runtime, with no compile-time signal.

src/Wfc/Utils/Attributes/ScenePathAttribute/ScenePathAttribute.cs:10–16
Fix
Split on the repository marker that actually exists on disk — "/src/" — or resolve against ProjectSettings.GlobalizePath("res://"). Either removes the dependency on a folder name no build step enforces.