### PR TITLE
Clear GD.Print and use logger class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -392,3 +392,12 @@ $RECYCLE.BIN/
 # Player settings, written by the running game into the working directory in a
 # development build. Local state, not project configuration.
 settings.ini
+
+# The build-output rules above match by directory name at any depth ([Ll]og/, [Dd]ebug/,
+# [Rr]elease/, [Bb]in/, [Oo]bj/ ...). This project names a directory after every type it
+# holds, so a type called Log or Debug had its entire folder ignored - and an ignored
+# directory is invisible to git status as well as to git add, so the file simply never
+# reaches a commit and CI is the first thing to notice. Nothing under src/ or test/ is
+# build output.
+!src/**/
+!test/**/

--- a/src/Wfc/Base/DependenciesProvider/DependenciesProvider.cs
+++ b/src/Wfc/Base/DependenciesProvider/DependenciesProvider.cs
@@ -35,14 +35,15 @@ public partial class DependenciesProvider :
   private readonly Lazy<IInputManager> _inputManager;
   private readonly Lazy<IModalStack> _modalStack;
   private readonly Lazy<IPauseOwnership> _pauseOwnership;
-  private readonly ILogger _logger = new GDLogger();
   private readonly SaveManager _saveManager = new SaveManager();
   IMenuManager IProvide<IMenuManager>.Value() => _menuManager.Value;
   IModalStack IProvide<IModalStack>.Value() => _modalStack.Value;
   IPauseOwnership IProvide<IPauseOwnership>.Value() => _pauseOwnership.Value;
   ISaveManager IProvide<ISaveManager>.Value() => _saveManager;
   ILocalizationService IProvide<ILocalizationService>.Value() => new LocalizationService();
-  ILogger IProvide<ILogger>.Value() => _logger;
+  // The same instance the static Log facade writes through: a node that takes ILogger as a
+  // dependency and a static class that cannot must not end up with two different floors.
+  ILogger IProvide<ILogger>.Value() => Log.Logger;
   IEventHandler IProvide<IEventHandler>.Value() => AutoloadManager.Instance.EventHandler;
   ISfxManager IProvide<ISfxManager>.Value() => AutoloadManager.Instance.SfxManager;
   IMusicTrackManager IProvide<IMusicTrackManager>.Value() => AutoloadManager.Instance.MusicTrackManager;

--- a/src/Wfc/Core/Audio/Music/MusicTrackManager/MusicTrackManager.cs
+++ b/src/Wfc/Core/Audio/Music/MusicTrackManager/MusicTrackManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using Godot;
 using Wfc.Core.Event;
+using Wfc.Core.Logger;
 using Wfc.Core.Persistence;
 using Wfc.Core.Serialization;
 using Wfc.Utils;
@@ -97,7 +98,7 @@ public partial class MusicTrackManager : Node2D, IMusicTrackManager, IPersistent
       AddTrack(name, track.Path, track.Volume);
     }
     else {
-      GD.PushError("Invalid track name: ", name);
+      Log.Error($"Invalid track name: {name}");
       return;
     }
   }
@@ -122,7 +123,7 @@ public partial class MusicTrackManager : Node2D, IMusicTrackManager, IPersistent
 
   public void RemoveTrack(string name) {
     if (!_musicPool.TryGetValue(name, out var value)) {
-      GD.PushError("Invalid track name to remove: ", name);
+      Log.Error($"Invalid track name to remove: {name}");
       return;
     }
 
@@ -136,7 +137,7 @@ public partial class MusicTrackManager : Node2D, IMusicTrackManager, IPersistent
 
   public void PlayTrack(string name) {
     if (!_musicPool.TryGetValue(name, out var value)) {
-      GD.PushError("Invalid track name to play: ", name);
+      Log.Error($"Invalid track name to play: {name}");
       return;
     }
     var track = value;

--- a/src/Wfc/Core/Audio/Sfx/SfxManager/SfxManager.cs
+++ b/src/Wfc/Core/Audio/Sfx/SfxManager/SfxManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using Godot;
 using Wfc.Core.Event;
+using Wfc.Core.Logger;
 using Wfc.Entities.World.Piano;
 using Wfc.Utils;
 using Wfc.Utils.Attributes;
@@ -33,7 +34,7 @@ public partial class SfxManager : Node2D, ISfxManager {
       // A sound the editor has not imported yet resolves to null, and taking the whole pool
       // down with it would leave the game silent rather than just that one effect.
       if (stream is null) {
-        GD.PushError("Could not load sfx stream: ", data.Path);
+        Log.Error($"Could not load sfx stream: {data.Path}");
         continue;
       }
       var audioPlayer = new AudioStreamPlayer {
@@ -157,7 +158,7 @@ public partial class SfxManager : Node2D, ISfxManager {
       value.Play();
     }
     else {
-      GD.PushError("Invalid sfx name: ", sfx);
+      Log.Error($"Invalid sfx name: {sfx}");
     }
   }
 

--- a/src/Wfc/Core/Event/EventHandler/EventHandler.cs
+++ b/src/Wfc/Core/Event/EventHandler/EventHandler.cs
@@ -4,6 +4,7 @@ using System;
 using Godot;
 using Wfc.Core.Input.Controllers;
 using Wfc.Core.Localization;
+using Wfc.Core.Logger;
 using Wfc.Entities.World;
 using Wfc.Entities.World.Piano;
 using Wfc.Screens.MenuManager;
@@ -83,7 +84,7 @@ public partial class EventHandler : Node, IEventHandler {
         return true;
       }
       else {
-        GD.PushError("error: " + error);
+        Log.Error("error: " + error);
       }
     }
     return false;

--- a/src/Wfc/Core/Localization/TranslationKey/TranslationKey.cs
+++ b/src/Wfc/Core/Localization/TranslationKey/TranslationKey.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Godot;
 using Wfc.Core.Exceptions;
+using Wfc.Core.Logger;
 using Wfc.Utils;
 
 // Note: Please only add entries at the end to preserve existing enum values declared in scene files.
@@ -136,7 +137,7 @@ public static partial class TranslationKeyExtensions {
       return key.ToTranslationKeyString();
     }
     catch (Exception ex) {
-      GD.PrintErr($"Failed to convert TranslationKey '{key}' to string: {ex.Message}");
+      Log.Error($"Failed to convert TranslationKey '{key}' to string: {ex.Message}");
       return string.Empty;
     }
   }

--- a/src/Wfc/Core/Logger/GDLogger/GDLogger.cs
+++ b/src/Wfc/Core/Logger/GDLogger/GDLogger.cs
@@ -1,9 +1,14 @@
 namespace Wfc.Core.Logger;
+
 using Godot;
 
 public class GDLogger : ILogger {
   public Severity Severity { get; set; } = Severity.Info;
 
+  // Each severity goes to the channel Godot sorts it into, rather than everything below an
+  // error going to the console. A warning printed as text is a warning nobody sees: the editor
+  // collects PushWarning into its own panel and counts it, and a headless run marks the line
+  // as a warning instead of leaving it in the middle of ordinary output.
   public void Log(Severity severity, string message) {
     if (Severity > severity) {
       return;
@@ -11,19 +16,17 @@ public class GDLogger : ILogger {
 
     switch (severity) {
       case Severity.Debug:
-        GD.Print(message);
-        break;
       case Severity.Info:
         GD.Print(message);
         break;
       case Severity.Warning:
-        GD.Print(message);
+        GD.PushWarning(message);
         break;
       case Severity.Error:
         GD.PushError(message);
         break;
       default:
-        GD.PushError("unknown severity: " + severity);
+        GD.PushError($"unknown severity {severity}: {message}");
         break;
     }
   }

--- a/src/Wfc/Core/Logger/Log/Log.cs
+++ b/src/Wfc/Core/Logger/Log/Log.cs
@@ -1,0 +1,33 @@
+namespace Wfc.Core.Logger;
+
+using System;
+
+// The one way the game says anything to the console.
+//
+// A static way in rather than an injected ILogger everywhere, because most of what has
+// something to report is not a node and AutoInject cannot reach it: the save files, the
+// settings, the path attributes, the serializers. A node that would rather take ILogger as a
+// dependency still can - DependenciesProvider hands out this same instance, so the severity
+// floor means the same thing whichever way a caller arrived.
+public static class Log {
+  // Swappable so a test can read back what was reported instead of watching the console, and
+  // so the floor below can be moved without any call site knowing.
+  public static ILogger Logger { get; set; } = new GDLogger();
+
+  // What is worth hearing about. Anything below this is dropped, which is what makes Debug
+  // usable for a running commentary that is off unless somebody asks for it.
+  public static Severity Severity {
+    get => Logger.Severity;
+    set => Logger.Severity = value;
+  }
+
+  public static void Debug(string message) => Logger.LogDebug(message);
+
+  public static void Info(string message) => Logger.LogInfo(message);
+
+  public static void Warning(string message) => Logger.LogWarning(message);
+
+  public static void Error(string message) => Logger.LogError(message);
+
+  public static void Exception(Exception exception) => Logger.LogException(exception);
+}

--- a/src/Wfc/Core/Logger/Log/Log.cs.uid
+++ b/src/Wfc/Core/Logger/Log/Log.cs.uid
@@ -1,0 +1,1 @@
+uid://cm0i0u0wd02hn

--- a/src/Wfc/Core/Persistence/SaveManager/SaveManager.cs
+++ b/src/Wfc/Core/Persistence/SaveManager/SaveManager.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Godot;
+using Wfc.Core.Logger;
 using Wfc.Core.Serialization;
 using Wfc.Entities.World.Camera;
 using Wfc.Entities.World.Player;
@@ -27,12 +28,12 @@ public partial class SaveManager : ISaveManager {
   public void SaveGame(SceneTree tree, int slotIndex) {
     slotIndex = slotIndex == ISaveManager.NO_SLOT ? Math.Max(0, LatestLoadedSlot) : slotIndex;
     if (slotIndex is < 0 or >= NUM_SLOTS) {
-      GD.PushError($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
+      Log.Error($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
       return;
     }
     _saveSlots[slotIndex].Save(_serializer, tree);
     _loadSlotsMetaData();
-    GD.Print("Game saved!");
+    Log.Debug($"Saved slot {slotIndex}.");
   }
 
   // Records how far the player has got and writes the slot out.
@@ -47,7 +48,7 @@ public partial class SaveManager : ISaveManager {
   public void RecordProgress(SceneTree tree, LevelId levelId, int progressPercent, int slotIndex = ISaveManager.NO_SLOT) {
     slotIndex = slotIndex == ISaveManager.NO_SLOT ? Math.Max(0, LatestLoadedSlot) : slotIndex;
     if (slotIndex is < 0 or >= NUM_SLOTS) {
-      GD.PushError($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
+      Log.Error($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
       return;
     }
 
@@ -66,7 +67,7 @@ public partial class SaveManager : ISaveManager {
   public void RecordLevelCleared(SceneTree tree, LevelId clearedLevelId, LevelId? nextLevelId, IEnumerable<string>? collectedGems = null, int slotIndex = ISaveManager.NO_SLOT) {
     slotIndex = slotIndex == ISaveManager.NO_SLOT ? Math.Max(0, LatestLoadedSlot) : slotIndex;
     if (slotIndex is < 0 or >= NUM_SLOTS) {
-      GD.PushError($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
+      Log.Error($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
       return;
     }
 
@@ -109,7 +110,7 @@ public partial class SaveManager : ISaveManager {
   public void RecordHubArrivalSeen(int slotIndex = ISaveManager.NO_SLOT) {
     slotIndex = slotIndex == ISaveManager.NO_SLOT ? Math.Max(0, LatestLoadedSlot) : slotIndex;
     if (slotIndex is < 0 or >= NUM_SLOTS) {
-      GD.PushError($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
+      Log.Error($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
       return;
     }
 
@@ -131,7 +132,7 @@ public partial class SaveManager : ISaveManager {
   public void LoadGame(SceneTree tree, Player player, GameCamera camera, int slotIndex = ISaveManager.NO_SLOT) {
     slotIndex = slotIndex == ISaveManager.NO_SLOT ? Math.Max(0, LatestLoadedSlot) : slotIndex;
     if (slotIndex is < 0 or >= NUM_SLOTS) {
-      GD.PushError($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
+      Log.Error($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
       return;
     }
     _saveSlots[slotIndex].Load(_serializer, tree);
@@ -142,13 +143,13 @@ public partial class SaveManager : ISaveManager {
     camera.SnapTo(player.GlobalPosition);
     LatestLoadedSlot = slotIndex;
     _saveSlotsInfo();
-    GD.Print("Game loaded!");
+    Log.Debug($"Loaded slot {slotIndex}.");
   }
 
   public bool IsSLotFilled(int slotIndex = ISaveManager.NO_SLOT) {
     slotIndex = slotIndex == ISaveManager.NO_SLOT ? Math.Max(0, LatestLoadedSlot) : slotIndex;
     if (slotIndex is < 0 or >= NUM_SLOTS) {
-      GD.PushError($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
+      Log.Error($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
       return false;
     }
     return _saveSlots[slotIndex].IsFilled;
@@ -157,7 +158,7 @@ public partial class SaveManager : ISaveManager {
   public SlotMetaData? GetSlotMetaData(int slotIndex = ISaveManager.NO_SLOT) {
     slotIndex = slotIndex == ISaveManager.NO_SLOT ? Math.Max(0, LatestLoadedSlot) : slotIndex;
     if (slotIndex is < 0 or >= NUM_SLOTS) {
-      GD.PushError($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
+      Log.Error($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
       return null;
     }
     return _saveSlots[slotIndex].MetaData;
@@ -184,7 +185,7 @@ public partial class SaveManager : ISaveManager {
   public void SelectSlot(int slotIndex = ISaveManager.NO_SLOT) {
     slotIndex = slotIndex == ISaveManager.NO_SLOT ? Math.Max(0, LatestLoadedSlot) : slotIndex;
     if (slotIndex is < 0 or >= NUM_SLOTS) {
-      GD.PushError($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
+      Log.Error($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
       return;
     }
     LatestLoadedSlot = slotIndex;
@@ -193,7 +194,7 @@ public partial class SaveManager : ISaveManager {
 
   public void RemoveSaveSlot(int slotIndex) {
     if (slotIndex is < 0 or >= NUM_SLOTS) {
-      GD.PushError($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
+      Log.Error($"Invalid slot index: {slotIndex}. Must be 0-{NUM_SLOTS - 1}");
       return;
     }
     _saveSlots[slotIndex].Delete();
@@ -236,7 +237,7 @@ public partial class SaveManager : ISaveManager {
       }
     }
     catch (JsonException error) {
-      GD.PushError($"Could not read {SLOT_INFO_PATH}: {error.Message}");
+      Log.Error($"Could not read {SLOT_INFO_PATH}: {error.Message}");
     }
   }
 
@@ -250,7 +251,7 @@ public partial class SaveManager : ISaveManager {
 
     var saveFile = FileAccess.Open(SLOT_INFO_PATH, FileAccess.ModeFlags.Write);
     if (saveFile == null) {
-      GD.PushError($"Could not write {SLOT_INFO_PATH}: {FileAccess.GetOpenError()}");
+      Log.Error($"Could not write {SLOT_INFO_PATH}: {FileAccess.GetOpenError()}");
       return;
     }
     var data = new Dictionary<string, object> { { LATEST_LOADED_SLOT_FIELD_NAME, LatestLoadedSlot } };

--- a/src/Wfc/Core/Persistence/SaveSlot/SaveSlot.cs
+++ b/src/Wfc/Core/Persistence/SaveSlot/SaveSlot.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Godot;
+using Wfc.Core.Logger;
 using Wfc.Core.Serialization;
 using Wfc.Screens.Levels;
 
@@ -169,7 +170,7 @@ public partial class SaveSlot {
       // A truncated or hand-edited file used to be an unhandled exception during start-up, which
       // meant the player could not even reach the screen that would let them delete the slot.
       // Degrading to "empty" leaves the slot visible and deletable.
-      GD.PushError($"Could not read {MetaPath}: {error.Message}. Treating the slot as empty.");
+      Log.Error($"Could not read {MetaPath}: {error.Message}. Treating the slot as empty.");
       MetaData = null;
     }
   }
@@ -203,12 +204,12 @@ public partial class SaveSlot {
       nodesData = serializer.Deserialize<Dictionary<string, string>>(line);
     }
     catch (JsonException error) {
-      GD.PushError($"Could not read {Path}: {error.Message}. Starting the level from the top.");
+      Log.Error($"Could not read {Path}: {error.Message}. Starting the level from the top.");
       return;
     }
 
     if (nodesData == null) {
-      GD.PushError($"Empty save file!");
+      Log.Error($"Empty save file!");
       return;
     }
 
@@ -222,7 +223,7 @@ public partial class SaveSlot {
         node.Load(serializer, nodeData.Value);
       }
       else {
-        GD.PushWarning($"Save entry '{nodeData.Key}' matches no node in the persist group; ignored.");
+        Log.Warning($"Save entry '{nodeData.Key}' matches no node in the persist group; ignored.");
       }
     }
   }
@@ -231,7 +232,7 @@ public partial class SaveSlot {
   // state written beside them would say has nothing to do with what they changed.
   public void SaveMetaData(ISerializer serializer) {
     if (MetaData == null) {
-      GD.PushError($"Slot {_slotIndex} has no metadata to write.");
+      Log.Error($"Slot {_slotIndex} has no metadata to write.");
       return;
     }
     _writeLineAtomic(MetaPath, serializer.Serialize(MetaData));
@@ -242,11 +243,11 @@ public partial class SaveSlot {
     var saveNodes = sceneTree.GetNodesInGroup(IPersistent.PERSISTENT_GROUP_NAME);
     foreach (var node in saveNodes) {
       if (node.SceneFilePath.Length == 0) {
-        GD.PushError($"persistent node '{node.Name}' is not an instanced scene, skipped");
+        Log.Error($"persistent node '{node.Name}' is not an instanced scene, skipped");
         continue;
       }
       if (node is not IPersistent persistent) {
-        GD.PushError($"persistent node '{node.Name}' does not implement IPersistent, skipped");
+        Log.Error($"persistent node '{node.Name}' does not implement IPersistent, skipped");
         continue;
       }
       var nodeData = persistent.Save(serializer);
@@ -260,7 +261,7 @@ public partial class SaveSlot {
     if (file == null) {
       // Open returns null rather than throwing, so an unchecked handle is a
       // NullReferenceException raised inside whichever signal callback asked for the load.
-      GD.PushError($"Could not open {path} for reading: {FileAccess.GetOpenError()}");
+      Log.Error($"Could not open {path} for reading: {FileAccess.GetOpenError()}");
       return null;
     }
     return file.GetLine();
@@ -279,14 +280,14 @@ public partial class SaveSlot {
     var directory = path.GetBaseDir();
     var directoryError = DirAccess.MakeDirRecursiveAbsolute(directory);
     if (directoryError is not Error.Ok and not Error.AlreadyExists) {
-      GD.PushError($"Could not create {directory}: {directoryError}");
+      Log.Error($"Could not create {directory}: {directoryError}");
       return false;
     }
 
     var tempPath = $"{path}.tmp";
     using (var file = FileAccess.Open(tempPath, FileAccess.ModeFlags.Write)) {
       if (file == null) {
-        GD.PushError($"Could not open {tempPath} for writing: {FileAccess.GetOpenError()}");
+        Log.Error($"Could not open {tempPath} for writing: {FileAccess.GetOpenError()}");
         return false;
       }
       file.StoreLine(line);
@@ -294,7 +295,7 @@ public partial class SaveSlot {
 
     var renameError = DirAccess.RenameAbsolute(tempPath, path);
     if (renameError != Error.Ok) {
-      GD.PushError($"Could not move {tempPath} onto {path}: {renameError}");
+      Log.Error($"Could not move {tempPath} onto {path}: {renameError}");
       return false;
     }
     return true;

--- a/src/Wfc/Core/Settings/GameSettings/GameSettings.cs
+++ b/src/Wfc/Core/Settings/GameSettings/GameSettings.cs
@@ -4,9 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Godot;
-using Microsoft.VisualBasic;
 using Wfc.Core.Input.Controllers;
 using Wfc.Core.Localization;
+using Wfc.Core.Logger;
 using Wfc.Skin;
 using Wfc.Utils;
 using EventHandler = Wfc.Core.Event.EventHandler;
@@ -514,7 +514,7 @@ public static class GameSettings {
       return;
     }
     if (value.As<string>() != "") {
-      GD.PushWarning($"Ignoring unreadable keyboard binding for '{action}'; keeping the current one.");
+      Log.Warning($"Ignoring unreadable keyboard binding for '{action}'; keeping the current one.");
     }
   }
 
@@ -539,7 +539,7 @@ public static class GameSettings {
       }
     }
 
-    GD.PushWarning($"Ignoring unreadable gamepad binding for '{action}': '{binding}'.");
+    Log.Warning($"Ignoring unreadable gamepad binding for '{action}': '{binding}'.");
   }
 
   // Falls back to the pre-user:// location, and only ever for the real settings path: the

--- a/src/Wfc/Entities/Ui/InputHint/InputHintBar/InputHintBar.cs
+++ b/src/Wfc/Entities/Ui/InputHint/InputHintBar/InputHintBar.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Godot;
 using Wfc.Core.Input.Controllers;
 using Wfc.Core.Localization;
+using Wfc.Core.Logger;
 using Wfc.Core.Settings;
 using Wfc.Utils;
 using EventHandler = Wfc.Core.Event.EventHandler;
@@ -90,7 +91,7 @@ public partial class InputHintBar : Control {
     if (card == null) {
       // Silence here would leave the screen advertising the wrong action with nothing
       // to say why, so a renamed or misspelt card is loud instead.
-      GD.PushError($"{nameof(InputHintBar)} has no card named '{cardName}'.");
+      Log.Error($"{nameof(InputHintBar)} has no card named '{cardName}'.");
     }
     return card;
   }

--- a/src/Wfc/Entities/Ui/SettingsUI/UISelect/UIDropdownButton/UIDropdownButton.cs
+++ b/src/Wfc/Entities/Ui/SettingsUI/UISelect/UIDropdownButton/UIDropdownButton.cs
@@ -4,6 +4,7 @@ using Chickensoft.AutoInject;
 using Chickensoft.Introspection;
 using Godot;
 using Wfc.Core.Input;
+using Wfc.Core.Logger;
 using Wfc.Core.Ui;
 using Wfc.Screens.MenuManager;
 using Wfc.Utils;
@@ -202,7 +203,7 @@ public partial class UIDropdownButton : Button, IDarkBackgroundAware {
     _arrowSpacerNode.Visible = hasChoice;
     _applyInk();
     if (_index < 0 || _index >= SelectDriver.Items.Count || _index >= SelectDriver.ItemValues.Count) {
-      GD.PrintErr("UIDropdownButton - invalid index ", _index);
+      Log.Error($"UIDropdownButton - invalid index {_index}");
       return;
     }
     _labelNode.Text = SelectDriver.Items[_index];

--- a/src/Wfc/Entities/Ui/SettingsUI/UISelect/UISelect/UISelectButton.cs
+++ b/src/Wfc/Entities/Ui/SettingsUI/UISelect/UISelect/UISelectButton.cs
@@ -5,6 +5,7 @@ using Chickensoft.AutoInject;
 using Chickensoft.Introspection;
 using Godot;
 using Wfc.Core.Input;
+using Wfc.Core.Logger;
 using Wfc.Utils;
 using Wfc.Utils.Attributes;
 
@@ -222,7 +223,7 @@ public partial class UISelectButton : Button, IDarkBackgroundAware {
       UpdateRectSize();
     }
     else {
-      GD.PrintErr("SelectDriver - invalid index ", _index);
+      Log.Error($"SelectDriver - invalid index {_index}");
     }
 
   }

--- a/src/Wfc/Entities/World/BrickBreaker/Powerups/BrickPowerUpHandler/BrickPowerUpHandler.cs
+++ b/src/Wfc/Entities/World/BrickBreaker/Powerups/BrickPowerUpHandler/BrickPowerUpHandler.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using Godot;
 using Wfc.Core.Event;
+using Wfc.Core.Logger;
 using Wfc.Utils;
 using Wfc.Utils.Attributes;
 using Wfc.Utils.Colors;
@@ -156,7 +157,7 @@ public partial class BrickPowerUpHandler : Node2D, IPowerUpHandler {
     // reached its own QueueFree and kept falling forever with its monitoring already
     // switched off. Report the authoring mistake and let the pickup itself still count.
     if (hitNode == null) {
-      GD.PushError($"Power-up '{powerUp.SceneFilePath}' has no OnHitScript; no effect applied.");
+      Log.Error($"Power-up '{powerUp.SceneFilePath}' has no OnHitScript; no effect applied.");
     }
     else if (CheckIfCanAddPowerup(hitNode)) {
       var hit = hitNode.Instantiate<PowerUpScript>();

--- a/src/Wfc/Entities/World/ButtonGame/ButtonGame/ButtonGame.cs
+++ b/src/Wfc/Entities/World/ButtonGame/ButtonGame/ButtonGame.cs
@@ -2,6 +2,7 @@ namespace Wfc.Entities.World.ButtonGame;
 
 using System.Collections.Generic;
 using Godot;
+using Wfc.Core.Logger;
 using Wfc.Core.Persistence;
 using Wfc.Core.Serialization;
 using Wfc.Utils;
@@ -252,7 +253,7 @@ public partial class ButtonGame : Node2D, IPersistent {
         return button;
       }
     }
-    GD.PushError($"{Name} has no button with index {index}.");
+    Log.Error($"{Name} has no button with index {index}.");
     return null;
   }
   #endregion Rounds

--- a/src/Wfc/Entities/World/Camera/CameraLocalizer/CameraLocalizer.cs
+++ b/src/Wfc/Entities/World/Camera/CameraLocalizer/CameraLocalizer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Chickensoft.AutoInject;
 using Chickensoft.Introspection;
 using Godot;
+using Wfc.Core.Logger;
 using Wfc.Screens.Levels;
 using Wfc.Utils;
 using Wfc.Utils.Attributes;
@@ -285,7 +286,7 @@ public partial class CameraLocalizer : Node2D {
       GameLevel.CameraNode.SetFollowNode(node);
     }
     else {
-      GD.PushError($"{Name} points at '{FollowPath}', which is no Node2D; the camera keeps following what it had.");
+      Log.Error($"{Name} points at '{FollowPath}', which is no Node2D; the camera keeps following what it had.");
     }
   }
 

--- a/src/Wfc/Entities/World/Camera/GameCamera/GameCamera.cs
+++ b/src/Wfc/Entities/World/Camera/GameCamera/GameCamera.cs
@@ -1,6 +1,7 @@
 namespace Wfc.Entities.World.Camera;
 
 using Godot;
+using Wfc.Core.Logger;
 using Wfc.Core.Persistence;
 using Wfc.Core.Serialization;
 using Wfc.Utils.Attributes;
@@ -229,7 +230,7 @@ public partial class GameCamera : Camera2D, IPersistent {
     }
     var target = GetNodeOrNull<Node2D>(FollowPath);
     if (target == null) {
-      GD.PushError($"Camera follow target '{FollowPath}' resolves to no Node2D; the camera keeps following what it had.");
+      Log.Error($"Camera follow target '{FollowPath}' resolves to no Node2D; the camera keeps following what it had.");
       return FollowNode;
     }
     return target;

--- a/src/Wfc/Entities/World/Checkpoints/CheckpointArea/CheckpointArea.cs
+++ b/src/Wfc/Entities/World/Checkpoints/CheckpointArea/CheckpointArea.cs
@@ -3,6 +3,7 @@ namespace Wfc.Entities.World.Checkpoints;
 using System.Collections.Generic;
 using Godot;
 using Wfc.Core.Localization;
+using Wfc.Core.Logger;
 using Wfc.Core.Persistence;
 using Wfc.Core.Serialization;
 using Wfc.Utils;
@@ -47,7 +48,7 @@ public partial class CheckpointArea : Area2D, IPersistent {
     base._Ready();
     this.WireNodes();
     if (string.IsNullOrEmpty(ColorGroup)) {
-      GD.PushError("ColorGroup cannot be null or empty");
+      Log.Error("ColorGroup cannot be null or empty");
     }
     _campfireNode.Settle(ColorGroup, _isChecked);
   }

--- a/src/Wfc/Entities/World/Platforms/PlatformSlider/PlatformSlider.cs
+++ b/src/Wfc/Entities/World/Platforms/PlatformSlider/PlatformSlider.cs
@@ -2,6 +2,7 @@ namespace Wfc.Entities.World.Platforms;
 
 using System.Collections.Generic;
 using Godot;
+using Wfc.Core.Logger;
 using Wfc.Core.Persistence;
 using Wfc.Core.Serialization;
 using Wfc.Utils;
@@ -163,7 +164,7 @@ public partial class PlatformSlider : Node2D, IPersistent {
     }
 
     if (_body is null) {
-      GD.PushError($"{Name} has no physics body to move: a slider drives the body it is parented to.");
+      Log.Error($"{Name} has no physics body to move: a slider drives the body it is parented to.");
       SetPhysicsProcess(false);
       return;
     }

--- a/src/Wfc/Entities/World/Player/Player/Player.cs
+++ b/src/Wfc/Entities/World/Player/Player/Player.cs
@@ -8,6 +8,7 @@ using Godot;
 using Wfc.Autoload;
 using Wfc.Core.Event;
 using Wfc.Core.Input;
+using Wfc.Core.Logger;
 using Wfc.Core.Persistence;
 using Wfc.Core.Serialization;
 using Wfc.Entities.World.Checkpoints;
@@ -260,7 +261,7 @@ public partial class Player : CharacterBody2D, IPersistent {
       // No face wears this color, so there is no orientation to respawn in. This used to fall
       // through with angle 0 - the bottom face - and overwrite a perfectly good save with an
       // orientation nobody asked for.
-      GD.PushError($"Checkpoint color group '{colorGroup}' matches no face of the player; keeping the previous respawn point.");
+      Log.Error($"Checkpoint color group '{colorGroup}' matches no face of the player; keeping the previous respawn point.");
       return;
     }
 

--- a/src/Wfc/Screens/Levels/LevelDispatcher/LevelDispatcher.cs
+++ b/src/Wfc/Screens/Levels/LevelDispatcher/LevelDispatcher.cs
@@ -3,6 +3,7 @@ namespace Wfc.Screens.Levels;
 using System.Collections.Generic;
 using Godot;
 using Wfc.Core.Localization;
+using Wfc.Core.Logger;
 using Wfc.Utils;
 
 public static class LevelDispatcher {
@@ -12,7 +13,7 @@ public static class LevelDispatcher {
     // already handles null: without this the miss surfaces as an NRE a frame later.
     var levelScene = GD.Load<PackedScene>(path);
     if (levelScene == null) {
-      GD.PushError($"No scene found for level {levelId} at '{path}'");
+      Log.Error($"No scene found for level {levelId} at '{path}'");
       return null;
     }
     var level = levelScene.Instantiate<GameLevel>();

--- a/src/Wfc/Screens/MenuManager/MenuManager/MenuManager.cs
+++ b/src/Wfc/Screens/MenuManager/MenuManager/MenuManager.cs
@@ -3,6 +3,7 @@ namespace Wfc.Screens.MenuManager;
 using System;
 using System.Collections.Generic;
 using Godot;
+using Wfc.Core.Logger;
 using Wfc.Screens.Levels;
 using Wfc.Screens.MenuManager.Menus.MainMenu;
 using Wfc.Screens.SettingsMenu;
@@ -63,13 +64,13 @@ public class MenuManager : IMenuManager {
 
     var scenePath = GetMenuScenePath(nextMenu);
     if (scenePath == null) {
-      GD.PushError($"No scene registered for menu {nextMenu}");
+      Log.Error($"No scene registered for menu {nextMenu}");
       return false;
     }
 
     var packedScene = GD.Load<PackedScene>(scenePath);
     if (packedScene == null) {
-      GD.PushError($"Could not load menu scene at {scenePath}");
+      Log.Error($"Could not load menu scene at {scenePath}");
       return false;
     }
 

--- a/src/Wfc/Screens/SceneOrchester/SceneOrchester.cs
+++ b/src/Wfc/Screens/SceneOrchester/SceneOrchester.cs
@@ -7,6 +7,7 @@ using Chickensoft.Introspection;
 using Godot;
 using Wfc.Core.Audio;
 using Wfc.Core.Event;
+using Wfc.Core.Logger;
 using Wfc.Core.Persistence;
 using Wfc.Core.Ui;
 using Wfc.Entities.Ui;
@@ -269,14 +270,14 @@ public partial class SceneOrchester : Node2D {
       MoveChild(_titleCardNode, GetChildCount() - 1);
     }
     else {
-      GD.PrintErr($"Could not Instantiate level {levelId}");
+      Log.Error($"Could not Instantiate level {levelId}");
     }
     return level;
   }
 
   private void OnLevelCleared() {
     if (_currentLevel == null || _currentLevelId == null) {
-      GD.PushError("LevelCleared raised with no current level: there is nothing to advance from.");
+      Log.Error("LevelCleared raised with no current level: there is nothing to advance from.");
       return;
     }
 

--- a/src/Wfc/Utils/Attributes/LevelPathAttribute/LevelPathAttribute.cs
+++ b/src/Wfc/Utils/Attributes/LevelPathAttribute/LevelPathAttribute.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Godot;
+using Wfc.Core.Logger;
 using DirAccess = Godot.DirAccess;
 using FileAccess = Godot.FileAccess;
 
@@ -36,7 +37,7 @@ public class LevelPathAttribute : Attribute {
           _type = PathType.Directory;
         }
         else {
-          GD.PushError($"No file or directory found at the path: {path}");
+          Log.Error($"No file or directory found at the path: {path}");
           _path = String.Empty;
         }
       }

--- a/src/Wfc/Utils/NodeHelpers/NodeHelpers.cs
+++ b/src/Wfc/Utils/NodeHelpers/NodeHelpers.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Godot;
+using Wfc.Core.Logger;
 using Wfc.Utils.Attributes;
 
 public static class NodeHelpers {
@@ -33,9 +34,9 @@ public static class NodeHelpers {
         else {
           // Debug info
           // foreach (var n in node.GetChildrenRecursive()) {
-          //   GD.PrintErr(n.GetPath());
+          //   Log.Error(n.GetPath());
           // }
-          GD.PrintErr($"Unable to assign node at path '{path}' to field '{field.Name}'.");
+          Log.Error($"Unable to assign node at path '{path}' to field '{field.Name}'.");
         }
       }
     }

--- a/test/Instrumented/src/Helpers/Fakes/FakeDependenciesProvider.cs
+++ b/test/Instrumented/src/Helpers/Fakes/FakeDependenciesProvider.cs
@@ -48,10 +48,9 @@ public partial class FakeDependenciesProvider :
   private readonly Lazy<IMenuManager> _menuManager;
   private readonly Lazy<IModalStack> _modalStack;
   private readonly Lazy<IPauseOwnership> _pauseOwnership;
-  private readonly ILogger _logger = new GDLogger();
 
   IEventHandler IProvide<IEventHandler>.Value() => EventHandler.Instance;
-  ILogger IProvide<ILogger>.Value() => _logger;
+  ILogger IProvide<ILogger>.Value() => Log.Logger;
   IMenuManager IProvide<IMenuManager>.Value() => _menuManager.Value;
   ISaveManager IProvide<ISaveManager>.Value() => Save;
   ILocalizationService IProvide<ILocalizationService>.Value() => new LocalizationService();

--- a/test/src/Wfc/Core/Logger/LoggerTests.cs
+++ b/test/src/Wfc/Core/Logger/LoggerTests.cs
@@ -1,0 +1,99 @@
+namespace Wfc.Core.Logger.Test;
+
+using System;
+using System.Collections.Generic;
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+using Wfc.Core.Logger;
+
+// Everything the game reports goes through here, from static classes the injector cannot reach
+// as well as from nodes. Two things are worth pinning: that the floor actually drops what is
+// below it, and that each severity leaves by the channel Godot sorts it into - a warning
+// printed as ordinary text is a warning nobody ever sees.
+public class LoggerTests(Node testScene) : TestClass(testScene) {
+  private sealed class RecordingLogger : ILogger {
+    public Severity Severity { get; set; } = Severity.Debug;
+    public List<(Severity Level, string Message)> Written { get; } = [];
+    public void Log(Severity severity, string message) {
+      if (Severity > severity) {
+        return;
+      }
+      Written.Add((severity, message));
+    }
+  }
+
+  private ILogger _loggerBeforeTest = default!;
+  private RecordingLogger _recorder = default!;
+
+  [Setup]
+  public void Setup() {
+    _loggerBeforeTest = Log.Logger;
+    _recorder = new RecordingLogger();
+    Log.Logger = _recorder;
+  }
+
+  [Cleanup]
+  public void Cleanup() => Log.Logger = _loggerBeforeTest;
+
+  [Test]
+  public void EachCallCarriesItsOwnSeverityTest() {
+    Log.Debug("d");
+    Log.Info("i");
+    Log.Warning("w");
+    Log.Error("e");
+
+    _recorder.Written.ShouldBe([
+      (Severity.Debug, "d"),
+      (Severity.Info, "i"),
+      (Severity.Warning, "w"),
+      (Severity.Error, "e"),
+    ]);
+  }
+
+  // What makes Debug usable for a running commentary: it costs nothing unless asked for.
+  [Test]
+  public void AnythingBelowTheFloorIsDroppedTest() {
+    Log.Severity = Severity.Warning;
+
+    Log.Debug("d");
+    Log.Info("i");
+    Log.Warning("w");
+    Log.Error("e");
+
+    _recorder.Written.ShouldBe([(Severity.Warning, "w"), (Severity.Error, "e")]);
+  }
+
+  [Test]
+  public void TheFloorIsTheOneOnTheLoggerItselfTest() {
+    Log.Severity = Severity.Error;
+
+    Log.Logger.Severity.ShouldBe(Severity.Error);
+    Log.Severity.ShouldBe(Severity.Error);
+  }
+
+  [Test]
+  public void AnExceptionIsReportedAsAnErrorTest() {
+    Log.Exception(new InvalidOperationException("boom"));
+
+    _recorder.Written.Count.ShouldBe(1);
+    _recorder.Written[0].Level.ShouldBe(Severity.Error);
+    _recorder.Written[0].Message.ShouldContain("boom");
+  }
+
+  // The real logger, checked for the mapping rather than the output: a warning must not take
+  // the same path as an ordinary print.
+  [Test]
+  public void TheGodotLoggerKeepsItsFloorTest() {
+    // Through the interface, because LogDebug and friends are default interface methods and a
+    // concrete GDLogger does not carry them.
+    ILogger logger = new GDLogger { Severity = Severity.Error };
+
+    logger.Severity.ShouldBe(Severity.Error);
+
+    // Nothing below the floor reaches Godot at all; an error still does, and pushing one from a
+    // test is noise rather than failure, so only the floor itself is asserted here.
+    Should.NotThrow(() => logger.LogDebug("dropped"));
+    Should.NotThrow(() => logger.LogInfo("dropped"));
+  }
+}

--- a/test/src/Wfc/Core/Logger/LoggerTests.cs.uid
+++ b/test/src/Wfc/Core/Logger/LoggerTests.cs.uid
@@ -1,0 +1,1 @@
+uid://cu2c12ksog5nc


### PR DESCRIPTION
Debug output and a stray using survive in shipped code
SaveManager prints "Game saved!" and "Game loaded!" on every write and load — the house style forbids leaving GD.Print behind. GameSettings.cs imports Microsoft.VisualBasic, which nothing in the file uses.

SaveManager.cs:33, 143 · GameSettings.cs:7